### PR TITLE
PT-2650 Add property for data type to IndexDocumentField

### DIFF
--- a/src/VirtoCommerce.SearchModule.Core/Extenstions/IndexDocumentExtensions.cs
+++ b/src/VirtoCommerce.SearchModule.Core/Extenstions/IndexDocumentExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using VirtoCommerce.SearchModule.Core.Model;
@@ -22,7 +23,14 @@ namespace VirtoCommerce.SearchModule.Core.Extenstions
                 {
                     if (!string.IsNullOrWhiteSpace(value))
                     {
-                        document.Add(new IndexDocumentField(name, value) { IsRetrievable = true, IsFilterable = true, IsCollection = true });
+                        document.Add(new IndexDocumentField(name, value)
+                        {
+                            IsRetrievable = true,
+                            IsFilterable = true,
+                            IsCollection = true,
+                            ValueType = IndexDocumentFieldValueType.String,
+                        });
+
                         document.AddSearchableValue(value);
                     }
                 }
@@ -39,7 +47,13 @@ namespace VirtoCommerce.SearchModule.Core.Extenstions
         {
             if (!string.IsNullOrWhiteSpace(value))
             {
-                document.Add(new IndexDocumentField(name, value) { IsRetrievable = true, IsFilterable = true });
+                document.Add(new IndexDocumentField(name, value)
+                {
+                    IsRetrievable = true,
+                    IsFilterable = true,
+                    ValueType = IndexDocumentFieldValueType.String,
+                });
+
                 document.AddSearchableValue(value);
             }
         }
@@ -53,15 +67,39 @@ namespace VirtoCommerce.SearchModule.Core.Extenstions
         {
             if (!string.IsNullOrWhiteSpace(value))
             {
-                document.Add(new IndexDocumentField(SearchableFieldName, value) { IsRetrievable = true, IsSearchable = true, IsCollection = true });
+                document.Add(new IndexDocumentField(SearchableFieldName, value)
+                {
+                    IsRetrievable = true,
+                    IsSearchable = true,
+                    IsCollection = true,
+                    ValueType = IndexDocumentFieldValueType.String,
+                });
             }
         }
 
+        [Obsolete("Use overload AddFilterableValue(this IndexDocument document, string name, object value, IndexDocumentFieldValueType valueType).")]
         public static void AddFilterableValue(this IndexDocument document, string name, object value)
         {
             if (value != null)
             {
-                document.Add(new IndexDocumentField(name, value) { IsRetrievable = true, IsFilterable = true });
+                document.Add(new IndexDocumentField(name, value)
+                {
+                    IsRetrievable = true,
+                    IsFilterable = true,
+                });
+            }
+        }
+
+        public static void AddFilterableValue(this IndexDocument document, string name, object value, IndexDocumentFieldValueType valueType)
+        {
+            if (value != null)
+            {
+                document.Add(new IndexDocumentField(name, value)
+                {
+                    IsRetrievable = true,
+                    IsFilterable = true,
+                    ValueType = valueType,
+                });
             }
         }
 
@@ -73,7 +111,13 @@ namespace VirtoCommerce.SearchModule.Core.Extenstions
                 {
                     if (!string.IsNullOrWhiteSpace(value))
                     {
-                        document.Add(new IndexDocumentField(name, value) { IsRetrievable = true, IsFilterable = true, IsCollection = true });
+                        document.Add(new IndexDocumentField(name, value)
+                        {
+                            IsRetrievable = true,
+                            IsFilterable = true,
+                            IsCollection = true,
+                            ValueType = IndexDocumentFieldValueType.String,
+                        });
                     }
                 }
             }

--- a/src/VirtoCommerce.SearchModule.Core/Model/IndexDocumentField.cs
+++ b/src/VirtoCommerce.SearchModule.Core/Model/IndexDocumentField.cs
@@ -40,6 +40,8 @@ namespace VirtoCommerce.SearchModule.Core.Model
         public bool IsSearchable { get; set; }
         public bool IsCollection { get; set; }
 
+        public IndexDocumentFieldValueType ValueType { get; set; }
+
         public void Merge(IndexDocumentField field)
         {
             foreach (var value in field.Values)

--- a/src/VirtoCommerce.SearchModule.Core/Model/IndexDocumentFieldValueType.cs
+++ b/src/VirtoCommerce.SearchModule.Core/Model/IndexDocumentFieldValueType.cs
@@ -1,0 +1,21 @@
+namespace VirtoCommerce.SearchModule.Core.Model
+{
+    public enum IndexDocumentFieldValueType
+    {
+        Undefined,
+        String,
+        Char,
+        Guid,
+        Integer,
+        Double,
+        Short,
+        Byte,
+        Long,
+        Float,
+        Decimal,
+        DateTime,
+        Boolean,
+        GeoPoint,
+        Complex,
+    }
+}


### PR DESCRIPTION
## Description
Added enum IndexDocumentFieldValueType with collection of possible types for indexing. Value type no longer deducted via reflection, instead a user must inform mapper by himself using a value from enum. 
The old method is left for backward compatibility.

## References
### QA-test: PT-2651
### Jira-link: https://virtocommerce.atlassian.net/browse/PT-2648
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Search_3.15.0-pr-50.zip
