### PR TITLE
fix: Index endpoint now returns hangfire job id

### DIFF
--- a/src/VirtoCommerce.SearchModule.Core/Model/IndexProgressPushNotification.cs
+++ b/src/VirtoCommerce.SearchModule.Core/Model/IndexProgressPushNotification.cs
@@ -48,6 +48,11 @@ namespace VirtoCommerce.SearchModule.Core.Model
         [JsonProperty("errorCount")]
         public long ErrorCount { get; set; }
         /// <summary>
+        /// Get hangfire indexation job id
+        /// </summary>
+        [JsonProperty("jobId")]
+        public string JobId { get; set; }
+        /// <summary>
         /// Gets or sets the errors that has occurred during processing.
         /// </summary>
         /// <value>

--- a/src/VirtoCommerce.SearchModule.Data/BackgroundJobs/IndexingJobs.cs
+++ b/src/VirtoCommerce.SearchModule.Data/BackgroundJobs/IndexingJobs.cs
@@ -52,7 +52,7 @@ namespace VirtoCommerce.SearchModule.Data.BackgroundJobs
             var notification = IndexProgressHandler.CreateNotification(currentUserName, null);
 
             // Hangfire will set cancellation token.
-            BackgroundJob.Enqueue<IndexingJobs>(j => j.IndexAllDocumentsJob(currentUserName, notification.Id, options, null, JobCancellationToken.Null));
+            notification.JobId = BackgroundJob.Enqueue<IndexingJobs>(j => j.IndexAllDocumentsJob(currentUserName, notification.Id, options, null, JobCancellationToken.Null));
 
             return notification;
         }


### PR DESCRIPTION
## Description
Index endpoint now returns hangfire job id allowing to query for indexing completion
## References
### QA-test:
### Jira-link:
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Search_3.209.0-pr-69.zip
