### PR TITLE
PT-10127: System.NullReferenceException: Object reference not set to an in…

### DIFF
--- a/src/VirtoCommerce.SearchModule.Data/Services/Extensions.cs
+++ b/src/VirtoCommerce.SearchModule.Data/Services/Extensions.cs
@@ -27,7 +27,7 @@ namespace VirtoCommerce.SearchModule.Data.Services
             var builders = indexDocumentConfigurations
                 .Where(x => x.RelatedSources != null)
                 .SelectMany(x => x.RelatedSources)
-                .Where(x => x.ChangesProvider.GetType() == providerType)
+                .Where(x => x.ChangesProvider != null && x.ChangesProvider.GetType() == providerType)
                 .Select(x => x.DocumentBuilder);
 
             if (mainBuilder != null)


### PR DESCRIPTION
fix: System.NullReferenceException: Object reference not set to an instance of an object. at VirtoCommerce.SearchModule.Data.Services.Extensions.

## Description

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/PT-10127
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Search_3.216.0-pr-82-9b2f.zip
