### PR TITLE
PT-9841: Object reference not set to an instance of an object

### DIFF
--- a/src/VirtoCommerce.SearchModule.Data/BackgroundJobs/IndexingJobs.cs
+++ b/src/VirtoCommerce.SearchModule.Data/BackgroundJobs/IndexingJobs.cs
@@ -49,7 +49,8 @@ namespace VirtoCommerce.SearchModule.Data.BackgroundJobs
         public static void CancelIndexation()
         {
             var processingJob = JobStorage.Current.GetMonitoringApi().ProcessingJobs(0, int.MaxValue)
-                .FirstOrDefault(x => x.Value.Job.Method == _indexChangesJobMethod || x.Value.Job.Method == _manualIndexAllJobMethod);
+                .FirstOrDefault(x => x.Value?.Job?.Method == _indexChangesJobMethod ||
+                    x.Value?.Job?.Method == _manualIndexAllJobMethod);
 
             if (!string.IsNullOrEmpty(processingJob.Key))
             {


### PR DESCRIPTION
fix: Object reference not set to an instance of an object. at VirtoCommerce.SearchModule.Data.BackgroundJobs.IndexingJobs.

## Description

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/PT-9841
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Search_3.218.0-pr-84-2189.zip
