### PR TITLE
VCST-1901: Adds AddContentString with  languageCode

### DIFF
--- a/src/VirtoCommerce.SearchModule.Core/Extensions/IndexDocumentExtensions.cs
+++ b/src/VirtoCommerce.SearchModule.Core/Extensions/IndexDocumentExtensions.cs
@@ -114,6 +114,24 @@ public static class IndexDocumentExtensions
         document.AddSearchableCollection(ContentFieldName, value);
     }
 
+    /// <summary>
+    /// Adds given value to the searchable '__content_{languageCode}' collection with given language code.
+    /// If languageCode is null or empty, adds value to the searchable '__content' collection.
+    /// </summary>
+    /// <param name="document"></param>
+    /// <param name="value"></param>
+    /// <param name="languageCode"></param>
+    public static void AddContentString(this IndexDocument document, string value, string languageCode)
+    {
+        if (string.IsNullOrEmpty(languageCode))
+        {
+            document.AddSearchableCollection(ContentFieldName, value);
+        }
+        else
+        {
+            document.AddSearchableCollection($"{ContentFieldName}_{languageCode.ToLowerInvariant()}", value);
+        }
+    }
 
     public static void AddFilterableBoolean(this IndexDocument schema, string name)
     {


### PR DESCRIPTION
## Description
feat: Adds AddContentString(this IndexDocument document, string value, string languageCode) method into IndexDocumentExtensions. It adds a given value to the searchable '__content_{languageCode}' collection with the given language code. If languageCode is null or empty, it adds value to the searchable '__content' collection.

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-1901
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Search_3.805.0-pr-109-a6d8.zip