### PR TITLE
VCST-4328: Update to .NET10

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <!-- These properties will be shared for all projects -->
   <PropertyGroup>
-    <VersionPrefix>3.825.0</VersionPrefix>
+    <VersionPrefix>3.1000.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <VersionSuffix Condition=" '$(VersionSuffix)' != '' AND '$(BuildNumber)' != '' ">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
   </PropertyGroup>

--- a/src/VirtoCommerce.SearchModule.Core/VirtoCommerce.SearchModule.Core.csproj
+++ b/src/VirtoCommerce.SearchModule.Core/VirtoCommerce.SearchModule.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <noWarn>1591</noWarn>
     <IsPackable>true</IsPackable>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
@@ -13,7 +13,6 @@
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.917.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1002.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.SearchModule.Data/VirtoCommerce.SearchModule.Data.csproj
+++ b/src/VirtoCommerce.SearchModule.Data/VirtoCommerce.SearchModule.Data.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <noWarn>1591</noWarn>
     <IsPackable>true</IsPackable>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
@@ -18,8 +18,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Antlr4.Runtime.Standard" Version="4.13.1" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.917.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1002.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.SearchModule.Core\VirtoCommerce.SearchModule.Core.csproj" />

--- a/src/VirtoCommerce.SearchModule.Web/VirtoCommerce.SearchModule.Web.csproj
+++ b/src/VirtoCommerce.SearchModule.Web/VirtoCommerce.SearchModule.Web.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <noWarn>1591</noWarn>
     <OutputType>Library</OutputType>

--- a/src/VirtoCommerce.SearchModule.Web/module.manifest
+++ b/src/VirtoCommerce.SearchModule.Web/module.manifest
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <id>VirtoCommerce.Search</id>
-  <version>3.825.0</version>
+  <version>3.1000.0</version>
   <version-tag />
-  <platformVersion>3.917.0</platformVersion>
+  <platformVersion>3.1002.0</platformVersion>
   <dependencies></dependencies>
   <title>Search Core</title>
   <description>Defines Core Abstractions for indexed search functionality above different search providers, like: Elasticsearch, Azure Search, etc.</description>
@@ -17,7 +17,7 @@
   <iconUrl>Modules/$(VirtoCommerce.Search)/Content/logoVC.png</iconUrl>
   <requireLicenseAcceptance>false</requireLicenseAcceptance>
   <releaseNotes />
-  <copyright>Copyright © 2011–2025 Virto Commerce. All rights reserved</copyright>
+  <copyright>Copyright © 2011–2026 Virto Commerce. All rights reserved</copyright>
   <tags>security core</tags>
   <assemblyFile>VirtoCommerce.SearchModule.Web.dll</assemblyFile>
   <moduleType>VirtoCommerce.SearchModule.Web.Module, VirtoCommerce.SearchModule.Web</moduleType>

--- a/src/VirtoCommerce.SearchModule.Web/package-lock.json
+++ b/src/VirtoCommerce.SearchModule.Web/package-lock.json
@@ -416,10 +416,11 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"

--- a/tests/VirtoCommerce.SearchModule.Tests/PriorityTestCaseOrderer.cs
+++ b/tests/VirtoCommerce.SearchModule.Tests/PriorityTestCaseOrderer.cs
@@ -16,11 +16,33 @@ namespace VirtoCommerce.SearchModule.Tests
         private static int GetPriority(IXunitTestCase testCase)
         {
             // Order the test based on the attribute.
-            var type = Type.GetType(testCase.TestClassName);
+            var type = FindType(testCase.TestClassName);
             var methodInfo = type?.GetMethod(testCase.TestMethodName);
             var attr = methodInfo?.GetCustomAttribute<PriorityAttribute>();
 
             return attr?.Priority ?? 0;
+        }
+
+        private static Type FindType(string typeName)
+        {
+            // First try direct lookup (works for current assembly and mscorlib)
+            var type = Type.GetType(typeName);
+            if (type != null)
+            {
+                return type;
+            }
+
+            // Search all loaded assemblies for cross-assembly test classes
+            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                type = assembly.GetType(typeName);
+                if (type != null)
+                {
+                    return type;
+                }
+            }
+
+            return null;
         }
     }
 }

--- a/tests/VirtoCommerce.SearchModule.Tests/PriorityTestCaseOrderer.cs
+++ b/tests/VirtoCommerce.SearchModule.Tests/PriorityTestCaseOrderer.cs
@@ -1,29 +1,24 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using Xunit.Abstractions;
-using Xunit.Sdk;
+using Xunit.v3;
 
 namespace VirtoCommerce.SearchModule.Tests
 {
     public class PriorityTestCaseOrderer : ITestCaseOrderer
     {
-        public const string TypeName = "VirtoCommerce.SearchModule.Tests.PriorityTestCaseOrderer";
-        public const string AssemblyName = "VirtoCommerce.SearchModule.Tests";
-
-        public IEnumerable<TTestCase> OrderTestCases<TTestCase>(IEnumerable<TTestCase> testCases)
-            where TTestCase : ITestCase
+        IReadOnlyCollection<TTestCase> ITestCaseOrderer.OrderTestCases<TTestCase>(IReadOnlyCollection<TTestCase> testCases)
         {
-            return testCases.OrderByDescending(GetPriority);
+            return testCases.OrderByDescending(tc => GetPriority((IXunitTestCase)tc)).ToList();
         }
 
-        private static int GetPriority<TTestCase>(TTestCase testCase)
-            where TTestCase : ITestCase
+        private static int GetPriority(IXunitTestCase testCase)
         {
             // Order the test based on the attribute.
-            var attr = testCase.TestMethod.Method
-                .ToRuntimeMethod()
-                .GetCustomAttribute<PriorityAttribute>();
+            var type = Type.GetType(testCase.TestClassName);
+            var methodInfo = type?.GetMethod(testCase.TestMethodName);
+            var attr = methodInfo?.GetCustomAttribute<PriorityAttribute>();
 
             return attr?.Priority ?? 0;
         }

--- a/tests/VirtoCommerce.SearchModule.Tests/SearchProviderTests.cs
+++ b/tests/VirtoCommerce.SearchModule.Tests/SearchProviderTests.cs
@@ -9,7 +9,7 @@ using static VirtoCommerce.SearchModule.Core.Extensions.IndexDocumentExtensions;
 
 namespace VirtoCommerce.SearchModule.Tests
 {
-    [TestCaseOrderer(PriorityTestCaseOrderer.TypeName, PriorityTestCaseOrderer.AssemblyName)]
+    [TestCaseOrderer(typeof(PriorityTestCaseOrderer))]
     public abstract class SearchProviderTests : SearchProviderTestsBase
     {
         public const string DocumentType = "item";

--- a/tests/VirtoCommerce.SearchModule.Tests/VirtoCommerce.SearchModule.Tests.csproj
+++ b/tests/VirtoCommerce.SearchModule.Tests/VirtoCommerce.SearchModule.Tests.csproj
@@ -10,14 +10,13 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="VirtoCommerce.Testing" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.Testing" Version="3.1002.0" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.v3.runner.console" Version="3.2.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
     <PackageReference Include="FluentAssertions" Version="7.2.0" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/VirtoCommerce.SearchModule.Tests/VirtoCommerce.SearchModule.Tests.csproj
+++ b/tests/VirtoCommerce.SearchModule.Tests/VirtoCommerce.SearchModule.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <noWarn>1591</noWarn>
   </PropertyGroup>
   <ItemGroup>
@@ -8,19 +8,17 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.6.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.6.0" />
-    <PackageReference Include="VirtoCommerce.Testing" Version="3.917.0" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.console" Version="2.9.2">
+    <PackageReference Include="VirtoCommerce.Testing" Version="3.1000.0" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.v3.runner.console" Version="3.2.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
-    <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="FluentAssertions" Version="7.2.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\VirtoCommerce.SearchModule.Core\VirtoCommerce.SearchModule.Core.csproj" />


### PR DESCRIPTION
## Description
feat: Update to .NET10

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4328
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Search_3.1000.0-pr-130-f389.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moves all projects and tests to `net10.0` and upgrades core/platform and test dependencies, which can introduce runtime or build incompatibilities. Test infrastructure changes (xUnit v3 migration and custom ordering logic updates) may affect test discovery/execution order.
> 
> **Overview**
> Updates the module versioning (`3.1000.0`) and raises all projects (Core/Data/Web/Tests) from `net8.0` to `net10.0`.
> 
> Bumps VirtoCommerce platform package references to `3.1002.0`, updates the module manifest `platformVersion`, and refreshes test/tooling dependencies (migrates to `xunit.v3`, updates `Microsoft.NET.Test.Sdk`/`FluentAssertions`).
> 
> Adjusts custom test ordering to the xUnit v3 APIs and switches `[TestCaseOrderer]` usage to the type-based form; also updates the web `package-lock.json` with a minor `brace-expansion` patch.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f389a24838280869b1acf670f0f1b26002f9e514. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->