### PR TITLE
VCST-5000:  Add support for cancellation tokens for hangfire background jobs

### DIFF
--- a/src/VirtoCommerce.SearchModule.Core/Services/IIndexDocumentBuilder.cs
+++ b/src/VirtoCommerce.SearchModule.Core/Services/IIndexDocumentBuilder.cs
@@ -12,8 +12,7 @@ namespace VirtoCommerce.SearchModule.Core.Services;
 public interface IIndexDocumentBuilder
 {
     [Obsolete("Use the cancellation-aware overload instead.", DiagnosticId = "VC0014", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
-    Task<IList<IndexDocument>> GetDocumentsAsync(IList<string> documentIds)
-        => GetDocumentsAsync(documentIds, CancellationToken.None);
+    Task<IList<IndexDocument>> GetDocumentsAsync(IList<string> documentIds);
 
     /// <summary>
     /// Cancellation-aware overload. Implementations should poll the token at their own loop boundaries

--- a/src/VirtoCommerce.SearchModule.Core/Services/IIndexDocumentBuilder.cs
+++ b/src/VirtoCommerce.SearchModule.Core/Services/IIndexDocumentBuilder.cs
@@ -12,7 +12,8 @@ namespace VirtoCommerce.SearchModule.Core.Services;
 public interface IIndexDocumentBuilder
 {
     [Obsolete("Use the cancellation-aware overload instead.", DiagnosticId = "VC0014", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
-    Task<IList<IndexDocument>> GetDocumentsAsync(IList<string> documentIds);
+    Task<IList<IndexDocument>> GetDocumentsAsync(IList<string> documentIds)
+        => throw new NotImplementedException();
 
     /// <summary>
     /// Cancellation-aware overload. Implementations should poll the token at their own loop boundaries

--- a/src/VirtoCommerce.SearchModule.Core/Services/IIndexDocumentBuilder.cs
+++ b/src/VirtoCommerce.SearchModule.Core/Services/IIndexDocumentBuilder.cs
@@ -1,14 +1,28 @@
+using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using VirtoCommerce.SearchModule.Core.Model;
 
-namespace VirtoCommerce.SearchModule.Core.Services
+namespace VirtoCommerce.SearchModule.Core.Services;
+
+/// <summary>
+/// Used by indexing manager to get documents to be indexed
+/// </summary>
+public interface IIndexDocumentBuilder
 {
+    [Obsolete("Use the cancellation-aware overload instead.", DiagnosticId = "VC0014", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+    Task<IList<IndexDocument>> GetDocumentsAsync(IList<string> documentIds)
+        => GetDocumentsAsync(documentIds, CancellationToken.None);
+
     /// <summary>
-    /// Used by indexing manager to get documents to be indexed
+    /// Cancellation-aware overload. Implementations should poll the token at their own loop boundaries
+    /// (e.g. between document fetches or between paginated sub-queries) so that a Hangfire-deletion
+    /// of the owning job aborts the call promptly. The default implementation delegates to the
+    /// legacy overload to preserve backwards compatibility.
     /// </summary>
-    public interface IIndexDocumentBuilder
-    {
-        Task<IList<IndexDocument>> GetDocumentsAsync(IList<string> documentIds);
-    }
+    Task<IList<IndexDocument>> GetDocumentsAsync(IList<string> documentIds, CancellationToken cancellationToken)
+#pragma warning disable VC0014 // Type or member is obsolete
+        => GetDocumentsAsync(documentIds);
+#pragma warning restore VC0014 // Type or member is obsolete
 }

--- a/src/VirtoCommerce.SearchModule.Core/Services/IIndexDocumentChangeFeed.cs
+++ b/src/VirtoCommerce.SearchModule.Core/Services/IIndexDocumentChangeFeed.cs
@@ -23,7 +23,8 @@ public interface IIndexDocumentChangeFeed
     /// </summary>
     /// <returns>Batch of changes or null when at end of feed.</returns>
     [Obsolete("Use the cancellation-aware overload instead.", DiagnosticId = "VC0014", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
-    Task<IReadOnlyCollection<IndexDocumentChange>> GetNextBatch();
+    Task<IReadOnlyCollection<IndexDocumentChange>> GetNextBatch()
+         => throw new NotImplementedException();
 
     /// <summary>
     /// Cancellation-aware overload. Default implementation delegates to the legacy method for backwards compatibility.

--- a/src/VirtoCommerce.SearchModule.Core/Services/IIndexDocumentChangeFeed.cs
+++ b/src/VirtoCommerce.SearchModule.Core/Services/IIndexDocumentChangeFeed.cs
@@ -1,25 +1,36 @@
+using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using VirtoCommerce.SearchModule.Core.Model;
 
-namespace VirtoCommerce.SearchModule.Core.Services
+namespace VirtoCommerce.SearchModule.Core.Services;
+
+/// <summary>
+/// Stateful change feed for indexation.
+/// Storage sub systems should be able to implement this efficiently, whether it be SQL or NoSQL.
+/// </summary>
+public interface IIndexDocumentChangeFeed
 {
     /// <summary>
-    /// Stateful change feed for indexation.
-    /// Storage sub systems should be able to implement this efficiently, whether it be SQL or NoSQL.
+    /// Optional total count, feed is not required to implement this.
+    /// This is only informational so that the user might have an idea how long the process will still take.
     /// </summary>
-    public interface IIndexDocumentChangeFeed
-    {
-        /// <summary>
-        /// Optional total count, feed is not required to implement this.
-        /// This is only informational so that the user might have an idea how long the process will still take.
-        /// </summary>
-        long? TotalCount { get; }
+    long? TotalCount { get; }
 
-        /// <summary>
-        /// Gets the next batch with changes.
-        /// </summary>
-        /// <returns>Batch of changes or null when at end of feed.</returns>
-        Task<IReadOnlyCollection<IndexDocumentChange>> GetNextBatch();
-    }
+    /// <summary>
+    /// Gets the next batch with changes.
+    /// </summary>
+    /// <returns>Batch of changes or null when at end of feed.</returns>
+    [Obsolete("Use the cancellation-aware overload instead.", DiagnosticId = "VC0014", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+    Task<IReadOnlyCollection<IndexDocumentChange>> GetNextBatch()
+        => GetNextBatch(CancellationToken.None);
+
+    /// <summary>
+    /// Cancellation-aware overload. Default implementation delegates to the legacy method for backwards compatibility.
+    /// </summary>
+    Task<IReadOnlyCollection<IndexDocumentChange>> GetNextBatch(CancellationToken cancellationToken)
+#pragma warning disable VC0014 // Type or member is obsolete
+        => GetNextBatch();
+#pragma warning restore VC0014 // Type or member is obsolete
 }

--- a/src/VirtoCommerce.SearchModule.Core/Services/IIndexDocumentChangeFeed.cs
+++ b/src/VirtoCommerce.SearchModule.Core/Services/IIndexDocumentChangeFeed.cs
@@ -23,8 +23,7 @@ public interface IIndexDocumentChangeFeed
     /// </summary>
     /// <returns>Batch of changes or null when at end of feed.</returns>
     [Obsolete("Use the cancellation-aware overload instead.", DiagnosticId = "VC0014", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
-    Task<IReadOnlyCollection<IndexDocumentChange>> GetNextBatch()
-        => GetNextBatch(CancellationToken.None);
+    Task<IReadOnlyCollection<IndexDocumentChange>> GetNextBatch();
 
     /// <summary>
     /// Cancellation-aware overload. Default implementation delegates to the legacy method for backwards compatibility.

--- a/src/VirtoCommerce.SearchModule.Core/Services/IIndexDocumentChangeFeedFactory.cs
+++ b/src/VirtoCommerce.SearchModule.Core/Services/IIndexDocumentChangeFeedFactory.cs
@@ -17,8 +17,7 @@ public interface IIndexDocumentChangeFeedFactory
     /// <param name="batchSize">Size of the batches to use.</param>
     /// <returns>Created feed, never null.</returns>
     [Obsolete("Use the cancellation-aware overload instead.", DiagnosticId = "VC0014", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
-    Task<IIndexDocumentChangeFeed> CreateFeed(DateTime? startDate, DateTime? endDate, int batchSize)
-        => CreateFeed(startDate, endDate, batchSize, CancellationToken.None);
+    Task<IIndexDocumentChangeFeed> CreateFeed(DateTime? startDate, DateTime? endDate, int batchSize);
 
     /// <summary>
     /// Cancellation-aware overload. Default implementation delegates to the legacy method for backwards compatibility.

--- a/src/VirtoCommerce.SearchModule.Core/Services/IIndexDocumentChangeFeedFactory.cs
+++ b/src/VirtoCommerce.SearchModule.Core/Services/IIndexDocumentChangeFeedFactory.cs
@@ -1,20 +1,30 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
-namespace VirtoCommerce.SearchModule.Core.Services
+namespace VirtoCommerce.SearchModule.Core.Services;
+
+/// <summary>
+/// Allows creating a stateful change feed as a source for the indexation process.
+/// </summary>
+public interface IIndexDocumentChangeFeedFactory
 {
     /// <summary>
-    /// Allows creating a stateful change feed as a source for the indexation process.
+    /// Creates the change feed.
     /// </summary>
-    public interface IIndexDocumentChangeFeedFactory
-    {
-        /// <summary>
-        /// Creates the change feed.
-        /// </summary>
-        /// <param name="startDate">Start date as a filter for the changes.</param>
-        /// <param name="endDate">End date as a filter for the changes.</param>
-        /// <param name="batchSize">Size of the batches to use.</param>
-        /// <returns>Created feed, never null.</returns>
-        Task<IIndexDocumentChangeFeed> CreateFeed(DateTime? startDate, DateTime? endDate, int batchSize);
-    }
+    /// <param name="startDate">Start date as a filter for the changes.</param>
+    /// <param name="endDate">End date as a filter for the changes.</param>
+    /// <param name="batchSize">Size of the batches to use.</param>
+    /// <returns>Created feed, never null.</returns>
+    [Obsolete("Use the cancellation-aware overload instead.", DiagnosticId = "VC0014", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+    Task<IIndexDocumentChangeFeed> CreateFeed(DateTime? startDate, DateTime? endDate, int batchSize)
+        => CreateFeed(startDate, endDate, batchSize, CancellationToken.None);
+
+    /// <summary>
+    /// Cancellation-aware overload. Default implementation delegates to the legacy method for backwards compatibility.
+    /// </summary>
+    Task<IIndexDocumentChangeFeed> CreateFeed(DateTime? startDate, DateTime? endDate, int batchSize, CancellationToken cancellationToken)
+#pragma warning disable VC0014 // Type or member is obsolete
+        => CreateFeed(startDate, endDate, batchSize);
+#pragma warning restore VC0014 // Type or member is obsolete
 }

--- a/src/VirtoCommerce.SearchModule.Core/Services/IIndexDocumentChangeFeedFactory.cs
+++ b/src/VirtoCommerce.SearchModule.Core/Services/IIndexDocumentChangeFeedFactory.cs
@@ -17,7 +17,8 @@ public interface IIndexDocumentChangeFeedFactory
     /// <param name="batchSize">Size of the batches to use.</param>
     /// <returns>Created feed, never null.</returns>
     [Obsolete("Use the cancellation-aware overload instead.", DiagnosticId = "VC0014", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
-    Task<IIndexDocumentChangeFeed> CreateFeed(DateTime? startDate, DateTime? endDate, int batchSize);
+    Task<IIndexDocumentChangeFeed> CreateFeed(DateTime? startDate, DateTime? endDate, int batchSize)
+         => throw new NotImplementedException();
 
     /// <summary>
     /// Cancellation-aware overload. Default implementation delegates to the legacy method for backwards compatibility.

--- a/src/VirtoCommerce.SearchModule.Core/Services/IIndexDocumentChangesProvider.cs
+++ b/src/VirtoCommerce.SearchModule.Core/Services/IIndexDocumentChangesProvider.cs
@@ -15,15 +15,13 @@ public interface IIndexDocumentChangesProvider
     /// Returns total count of the changes in the given time interval. If both startDate and endDate are null, returns total count of all available objects.
     /// </summary>
     [Obsolete("Use the cancellation-aware overload instead.", DiagnosticId = "VC0014", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
-    Task<long> GetTotalChangesCountAsync(DateTime? startDate, DateTime? endDate)
-        => GetTotalChangesCountAsync(startDate, endDate, CancellationToken.None);
+    Task<long> GetTotalChangesCountAsync(DateTime? startDate, DateTime? endDate);
 
     /// <summary>
     /// Returns IDs of objects changed in the given time interval. If both startDate and endDate are null, returns IDs of all available objects.
     /// </summary>
     [Obsolete("Use the cancellation-aware overload instead.", DiagnosticId = "VC0014", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
-    Task<IList<IndexDocumentChange>> GetChangesAsync(DateTime? startDate, DateTime? endDate, long skip, long take)
-                => GetChangesAsync(startDate, endDate, skip, take, CancellationToken.None);
+    Task<IList<IndexDocumentChange>> GetChangesAsync(DateTime? startDate, DateTime? endDate, long skip, long take);
 
     /// <summary>
     /// Cancellation-aware overload. Default implementation delegates to the legacy method for backwards compatibility.

--- a/src/VirtoCommerce.SearchModule.Core/Services/IIndexDocumentChangesProvider.cs
+++ b/src/VirtoCommerce.SearchModule.Core/Services/IIndexDocumentChangesProvider.cs
@@ -7,8 +7,20 @@ using VirtoCommerce.SearchModule.Core.Model;
 namespace VirtoCommerce.SearchModule.Core.Services;
 
 /// <summary>
-/// Used by indexing manager to find objects to be indexed
+/// Used by indexing manager to find objects to be indexed.
 /// </summary>
+/// <remarks>
+/// IMPLEMENTATION CONTRACT — please read.<br/>
+/// Each pair of overloads on this interface follows the same pattern:
+/// the legacy (no-token) overload is abstract, and the cancellation-aware overload has a default
+/// implementation that forwards to it. This guarantees that an empty implementation
+/// (<c>class Foo : IIndexDocumentChangesProvider { }</c>) does not compile, and that the default
+/// forwarding cannot create infinite recursion at runtime.<br/>
+/// <b>Do not</b> implement a legacy overload as a one-line forwarder to its cancellation-aware
+/// counterpart unless you also override the cancellation-aware overload with a real body — that
+/// pattern produces a StackOverflowException on the first call. Real work goes in one method;
+/// the other is a thin forwarder.
+/// </remarks>
 public interface IIndexDocumentChangesProvider
 {
     /// <summary>
@@ -18,18 +30,19 @@ public interface IIndexDocumentChangesProvider
     Task<long> GetTotalChangesCountAsync(DateTime? startDate, DateTime? endDate);
 
     /// <summary>
-    /// Returns IDs of objects changed in the given time interval. If both startDate and endDate are null, returns IDs of all available objects.
-    /// </summary>
-    [Obsolete("Use the cancellation-aware overload instead.", DiagnosticId = "VC0014", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
-    Task<IList<IndexDocumentChange>> GetChangesAsync(DateTime? startDate, DateTime? endDate, long skip, long take);
-
-    /// <summary>
     /// Cancellation-aware overload. Default implementation delegates to the legacy method for backwards compatibility.
+    /// Override when your implementation can honour cancellation.
     /// </summary>
     Task<long> GetTotalChangesCountAsync(DateTime? startDate, DateTime? endDate, CancellationToken cancellationToken)
 #pragma warning disable VC0014 // Type or member is obsolete
         => GetTotalChangesCountAsync(startDate, endDate);
 #pragma warning restore VC0014 // Type or member is obsolete
+
+    /// <summary>
+    /// Returns IDs of objects changed in the given time interval. If both startDate and endDate are null, returns IDs of all available objects.
+    /// </summary>
+    [Obsolete("Use the cancellation-aware overload instead.", DiagnosticId = "VC0014", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+    Task<IList<IndexDocumentChange>> GetChangesAsync(DateTime? startDate, DateTime? endDate, long skip, long take);
 
     /// <summary>
     /// Cancellation-aware overload. Implementations should poll the token at loop boundaries

--- a/src/VirtoCommerce.SearchModule.Core/Services/IIndexDocumentChangesProvider.cs
+++ b/src/VirtoCommerce.SearchModule.Core/Services/IIndexDocumentChangesProvider.cs
@@ -7,27 +7,17 @@ using VirtoCommerce.SearchModule.Core.Model;
 namespace VirtoCommerce.SearchModule.Core.Services;
 
 /// <summary>
-/// Used by indexing manager to find objects to be indexed.
+/// Represents a provider of document changes for a specific document type.
+/// The indexing process uses it to retrieve the changes to be indexed.
 /// </summary>
-/// <remarks>
-/// IMPLEMENTATION CONTRACT — please read.<br/>
-/// Each pair of overloads on this interface follows the same pattern:
-/// the legacy (no-token) overload is abstract, and the cancellation-aware overload has a default
-/// implementation that forwards to it. This guarantees that an empty implementation
-/// (<c>class Foo : IIndexDocumentChangesProvider { }</c>) does not compile, and that the default
-/// forwarding cannot create infinite recursion at runtime.<br/>
-/// <b>Do not</b> implement a legacy overload as a one-line forwarder to its cancellation-aware
-/// counterpart unless you also override the cancellation-aware overload with a real body — that
-/// pattern produces a StackOverflowException on the first call. Real work goes in one method;
-/// the other is a thin forwarder.
-/// </remarks>
 public interface IIndexDocumentChangesProvider
 {
     /// <summary>
     /// Returns total count of the changes in the given time interval. If both startDate and endDate are null, returns total count of all available objects.
     /// </summary>
     [Obsolete("Use the cancellation-aware overload instead.", DiagnosticId = "VC0014", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
-    Task<long> GetTotalChangesCountAsync(DateTime? startDate, DateTime? endDate);
+    Task<long> GetTotalChangesCountAsync(DateTime? startDate, DateTime? endDate)
+         => throw new NotImplementedException();
 
     /// <summary>
     /// Cancellation-aware overload. Default implementation delegates to the legacy method for backwards compatibility.
@@ -42,7 +32,8 @@ public interface IIndexDocumentChangesProvider
     /// Returns IDs of objects changed in the given time interval. If both startDate and endDate are null, returns IDs of all available objects.
     /// </summary>
     [Obsolete("Use the cancellation-aware overload instead.", DiagnosticId = "VC0014", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
-    Task<IList<IndexDocumentChange>> GetChangesAsync(DateTime? startDate, DateTime? endDate, long skip, long take);
+    Task<IList<IndexDocumentChange>> GetChangesAsync(DateTime? startDate, DateTime? endDate, long skip, long take)
+         => throw new NotImplementedException();
 
     /// <summary>
     /// Cancellation-aware overload. Implementations should poll the token at loop boundaries

--- a/src/VirtoCommerce.SearchModule.Core/Services/IIndexDocumentChangesProvider.cs
+++ b/src/VirtoCommerce.SearchModule.Core/Services/IIndexDocumentChangesProvider.cs
@@ -1,31 +1,45 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using VirtoCommerce.SearchModule.Core.Model;
 
-namespace VirtoCommerce.SearchModule.Core.Services
+namespace VirtoCommerce.SearchModule.Core.Services;
+
+/// <summary>
+/// Used by indexing manager to find objects to be indexed
+/// </summary>
+public interface IIndexDocumentChangesProvider
 {
     /// <summary>
-    /// Used by indexing manager to find objects to be indexed
+    /// Returns total count of the changes in the given time interval. If both startDate and endDate are null, returns total count of all available objects.
     /// </summary>
-    public interface IIndexDocumentChangesProvider
-    {
-        /// <summary>
-        /// Returns total count of the changes in the given time interval. If both startDate and endDate are null, returns total count of all available objects.
-        /// </summary>
-        /// <param name="startDate"></param>
-        /// <param name="endDate"></param>
-        /// <returns></returns>
-        Task<long> GetTotalChangesCountAsync(DateTime? startDate, DateTime? endDate);
+    [Obsolete("Use the cancellation-aware overload instead.", DiagnosticId = "VC0014", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+    Task<long> GetTotalChangesCountAsync(DateTime? startDate, DateTime? endDate)
+        => GetTotalChangesCountAsync(startDate, endDate, CancellationToken.None);
 
-        /// <summary>
-        /// Returns IDs of objects changed in the given time interval. If both startDate and endDate are null, returns IDs of all available objects.
-        /// </summary>
-        /// <param name="startDate"></param>
-        /// <param name="endDate"></param>
-        /// <param name="skip"></param>
-        /// <param name="take"></param>
-        /// <returns></returns>
-        Task<IList<IndexDocumentChange>> GetChangesAsync(DateTime? startDate, DateTime? endDate, long skip, long take);
-    }
+    /// <summary>
+    /// Returns IDs of objects changed in the given time interval. If both startDate and endDate are null, returns IDs of all available objects.
+    /// </summary>
+    [Obsolete("Use the cancellation-aware overload instead.", DiagnosticId = "VC0014", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+    Task<IList<IndexDocumentChange>> GetChangesAsync(DateTime? startDate, DateTime? endDate, long skip, long take)
+                => GetChangesAsync(startDate, endDate, skip, take, CancellationToken.None);
+
+    /// <summary>
+    /// Cancellation-aware overload. Default implementation delegates to the legacy method for backwards compatibility.
+    /// </summary>
+    Task<long> GetTotalChangesCountAsync(DateTime? startDate, DateTime? endDate, CancellationToken cancellationToken)
+#pragma warning disable VC0014 // Type or member is obsolete
+        => GetTotalChangesCountAsync(startDate, endDate);
+#pragma warning restore VC0014 // Type or member is obsolete
+
+    /// <summary>
+    /// Cancellation-aware overload. Implementations should poll the token at loop boundaries
+    /// so that a Hangfire-deletion of the owning indexing job aborts the call promptly.
+    /// Default implementation delegates to the legacy method for backwards compatibility.
+    /// </summary>
+    Task<IList<IndexDocumentChange>> GetChangesAsync(DateTime? startDate, DateTime? endDate, long skip, long take, CancellationToken cancellationToken)
+#pragma warning disable VC0014 // Type or member is obsolete
+        => GetChangesAsync(startDate, endDate, skip, take);
+#pragma warning restore VC0014 // Type or member is obsolete
 }

--- a/src/VirtoCommerce.SearchModule.Core/Services/IIndexingManager.cs
+++ b/src/VirtoCommerce.SearchModule.Core/Services/IIndexingManager.cs
@@ -53,7 +53,8 @@ public interface IIndexingManager
     /// <param name="builderTypes">Index document builder types to process the changed documents</param>
     /// <returns>Result of indexing operation.</returns>
     [Obsolete("Use the cancellation-aware overload instead.", DiagnosticId = "VC0014", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
-    Task<IndexingResult> IndexDocumentsAsync(string documentType, string[] documentIds, IEnumerable<string> builderTypes = null);
+    Task<IndexingResult> IndexDocumentsAsync(string documentType, string[] documentIds, IEnumerable<string> builderTypes = null)
+         => throw new NotImplementedException();
 
     /// <summary>
     /// Cancellation-aware overload of <see cref="IndexDocumentsAsync(string, string[], IEnumerable{string})"/>.
@@ -71,7 +72,8 @@ public interface IIndexingManager
     /// <param name="documentIds">Ids of documents to delete.</param>
     /// <returns>Result of indexing operation.</returns>
     [Obsolete("Use the cancellation-aware overload instead.", DiagnosticId = "VC0014", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
-    Task<IndexingResult> DeleteDocumentsAsync(string documentType, string[] documentIds);
+    Task<IndexingResult> DeleteDocumentsAsync(string documentType, string[] documentIds)
+         => throw new NotImplementedException();
 
     /// <summary>
     /// Cancellation-aware overload of <see cref="DeleteDocumentsAsync(string, string[])"/>.

--- a/src/VirtoCommerce.SearchModule.Core/Services/IIndexingManager.cs
+++ b/src/VirtoCommerce.SearchModule.Core/Services/IIndexingManager.cs
@@ -72,8 +72,7 @@ public interface IIndexingManager
     /// <param name="documentIds">Ids of documents to delete.</param>
     /// <returns>Result of indexing operation.</returns>
     [Obsolete("Use the cancellation-aware overload instead.", DiagnosticId = "VC0014", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
-    Task<IndexingResult> DeleteDocumentsAsync(string documentType, string[] documentIds)
-        => DeleteDocumentsAsync(documentType, documentIds, CancellationToken.None);
+    Task<IndexingResult> DeleteDocumentsAsync(string documentType, string[] documentIds);
 
     /// <summary>
     /// Cancellation-aware overload of <see cref="DeleteDocumentsAsync(string, string[])"/>.

--- a/src/VirtoCommerce.SearchModule.Core/Services/IIndexingManager.cs
+++ b/src/VirtoCommerce.SearchModule.Core/Services/IIndexingManager.cs
@@ -53,8 +53,7 @@ public interface IIndexingManager
     /// <param name="builderTypes">Index document builder types to process the changed documents</param>
     /// <returns>Result of indexing operation.</returns>
     [Obsolete("Use the cancellation-aware overload instead.", DiagnosticId = "VC0014", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
-    Task<IndexingResult> IndexDocumentsAsync(string documentType, string[] documentIds, IEnumerable<string> builderTypes = null)
-        => IndexDocumentsAsync(documentType, documentIds, builderTypes, CancellationToken.None);
+    Task<IndexingResult> IndexDocumentsAsync(string documentType, string[] documentIds, IEnumerable<string> builderTypes = null);
 
     /// <summary>
     /// Cancellation-aware overload of <see cref="IndexDocumentsAsync(string, string[], IEnumerable{string})"/>.

--- a/src/VirtoCommerce.SearchModule.Core/Services/IIndexingManager.cs
+++ b/src/VirtoCommerce.SearchModule.Core/Services/IIndexingManager.cs
@@ -1,56 +1,86 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
-using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.SearchModule.Core.Model;
 
-namespace VirtoCommerce.SearchModule.Core.Services
+namespace VirtoCommerce.SearchModule.Core.Services;
+
+/// <summary>
+/// Responsible for the functionality of indexing
+/// </summary>
+public interface IIndexingManager
 {
     /// <summary>
-    /// Responsible for the functionality of indexing
+    /// Return actual index stats for specific document type
     /// </summary>
-    public interface IIndexingManager
-    {
-        /// <summary>
-        /// Return actual index stats for specific document type
-        /// </summary>
-        /// <param name="documentType"></param>
-        /// <returns></returns>
-        Task<IndexState> GetIndexStateAsync(string documentType);
+    Task<IndexState> GetIndexStateAsync(string documentType);
 
-        /// <summary>
-        /// Return actual index stats for specific document type including backup indices if the Search Providers supports blue-green indexation.
-        /// </summary>
-        Task<IEnumerable<IndexState>> GetIndicesStateAsync(string documentType);
+    /// <summary>
+    /// Return actual index stats for specific document type including backup indices if the Search Providers supports blue-green indexation.
+    /// </summary>
+    Task<IEnumerable<IndexState>> GetIndicesStateAsync(string documentType);
 
-        Task IndexAllDocumentsAsync(IndexingOptions options, Action<IndexingProgress> progressCallback, ICancellationToken cancellationToken);
+    /// <summary>
+    /// Asynchronously indexes all documents using the specified options and reports progress through a callback.
+    /// </summary>
+    /// <remarks>The method processes all available documents according to the provided options. Progress
+    /// updates are reported periodically if a callback is supplied. The operation can be cancelled by signaling the
+    /// provided cancellation token.</remarks>
+    /// <param name="options">The options that configure the indexing operation, such as filters, batch size, or indexing behavior. Cannot be
+    /// null.</param>
+    /// <param name="progressCallback">A callback invoked to report indexing progress. Receives updates as <see cref="IndexingProgress"/> instances.
+    /// Can be null if progress reporting is not required.</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the indexing operation.</param>
+    /// <returns>A task that represents the asynchronous indexing operation.</returns>
+    Task IndexAllDocumentsAsync(IndexingOptions options, Action<IndexingProgress> progressCallback, CancellationToken cancellationToken);
 
-        Task IndexChangesAsync(IndexingOptions options, Action<IndexingProgress> progressCallback, ICancellationToken cancellationToken);
+    /// <summary>
+    /// Indexing the changes in the specified time interval. If both startDate and endDate are null, indexes all available objects.
+    /// </summary>
+    Task IndexChangesAsync(IndexingOptions options, Action<IndexingProgress> progressCallback, CancellationToken cancellationToken);
 
-        /// <summary>
-        /// Indexing the specified documents with given options
-        /// </summary>
-        /// <param name="options"></param>
-        /// <param name="progressCallback"></param>
-        /// <param name="cancellationToken"></param>
-        /// <returns></returns>
-        Task IndexAsync(IndexingOptions options, Action<IndexingProgress> progressCallback, ICancellationToken cancellationToken);
+    /// <summary>
+    /// Indexing the specified documents with given options
+    /// </summary>
+    Task IndexAsync(IndexingOptions options, Action<IndexingProgress> progressCallback, CancellationToken cancellationToken);
 
-        /// <summary>
-        /// Indexes a batch of documents immediately. Intended to be used by IndexingJobs.
-        /// </summary>
-        /// <param name="documentType">Document type to index.</param>
-        /// <param name="documentIds">Ids of documents to index.</param>
-        /// <param name="builderTypes">Index document builder types to process the changed documents</param>
-        /// <returns>Result of indexing operation.</returns>
-        Task<IndexingResult> IndexDocumentsAsync(string documentType, string[] documentIds, IEnumerable<string> builderTypes = null);
+    /// <summary>
+    /// Indexes a batch of documents immediately. Intended to be used by IndexingJobs.
+    /// </summary>
+    /// <param name="documentType">Document type to index.</param>
+    /// <param name="documentIds">Ids of documents to index.</param>
+    /// <param name="builderTypes">Index document builder types to process the changed documents</param>
+    /// <returns>Result of indexing operation.</returns>
+    [Obsolete("Use the cancellation-aware overload instead.", DiagnosticId = "VC0014", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+    Task<IndexingResult> IndexDocumentsAsync(string documentType, string[] documentIds, IEnumerable<string> builderTypes = null)
+        => IndexDocumentsAsync(documentType, documentIds, builderTypes, CancellationToken.None);
 
-        /// <summary>
-        /// Deletes a batch of documents from the index immediately. Intended to be used by IndexingJobs.
-        /// </summary>
-        /// <param name="documentType">Document type to delete.</param>
-        /// <param name="documentIds">Ids of documents to delete.</param>
-        /// <returns>Result of indexing operation.</returns>
-        Task<IndexingResult> DeleteDocumentsAsync(string documentType, string[] documentIds);
-    }
+    /// <summary>
+    /// Cancellation-aware overload of <see cref="IndexDocumentsAsync(string, string[], IEnumerable{string})"/>.
+    /// Default implementation delegates to the legacy overload for backwards compatibility.
+    /// </summary>
+    Task<IndexingResult> IndexDocumentsAsync(string documentType, string[] documentIds, IEnumerable<string> builderTypes, CancellationToken cancellationToken)
+#pragma warning disable VC0014 // Type or member is obsolete
+        => IndexDocumentsAsync(documentType, documentIds, builderTypes);
+#pragma warning restore VC0014 // Type or member is obsolete
+
+    /// <summary>
+    /// Deletes a batch of documents from the index immediately. Intended to be used by IndexingJobs.
+    /// </summary>
+    /// <param name="documentType">Document type to delete.</param>
+    /// <param name="documentIds">Ids of documents to delete.</param>
+    /// <returns>Result of indexing operation.</returns>
+    [Obsolete("Use the cancellation-aware overload instead.", DiagnosticId = "VC0014", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+    Task<IndexingResult> DeleteDocumentsAsync(string documentType, string[] documentIds)
+        => DeleteDocumentsAsync(documentType, documentIds, CancellationToken.None);
+
+    /// <summary>
+    /// Cancellation-aware overload of <see cref="DeleteDocumentsAsync(string, string[])"/>.
+    /// Default implementation delegates to the legacy overload for backwards compatibility.
+    /// </summary>
+    Task<IndexingResult> DeleteDocumentsAsync(string documentType, string[] documentIds, CancellationToken cancellationToken)
+#pragma warning disable VC0014 // Type or member is obsolete
+        => DeleteDocumentsAsync(documentType, documentIds);
+#pragma warning restore VC0014 // Type or member is obsolete
 }

--- a/src/VirtoCommerce.SearchModule.Data/BackgroundJobs/IndexingJobs.cs
+++ b/src/VirtoCommerce.SearchModule.Data/BackgroundJobs/IndexingJobs.cs
@@ -115,7 +115,11 @@ public sealed class IndexingJobs : IIndexingJobService
     }
 
 
-    // One-time job for manual indexation
+    // One-time job for manual indexation.
+    // The IJobCancellationToken-flavored overload below is a Hangfire compatibility shim for
+    // queue items enqueued before the CancellationToken-based signature was introduced.
+    // ShutdownToken only fires on server shutdown (NOT Hangfire-side deletion), so jobs that
+    // flow through the shim are less responsive to "Delete" until the queue has fully drained.
     [Queue(JobPriority.Normal)]
     public async Task IndexAllDocumentsJob(string userName, string notificationId, IndexingOptions[] options, PerformContext context, CancellationToken cancellationToken)
     {
@@ -130,8 +134,14 @@ public sealed class IndexingJobs : IIndexingJobService
         }
     }
 
+    [Queue(JobPriority.Normal)]
+    [Obsolete("Hangfire compatibility shim for legacy queue items. Use the overload with CancellationToken.", DiagnosticId = "VC0014", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+    public Task IndexAllDocumentsJob(string userName, string notificationId, IndexingOptions[] options, PerformContext context, IJobCancellationToken cancellationToken)
+        => IndexAllDocumentsJob(userName, notificationId, options, context, cancellationToken?.ShutdownToken ?? CancellationToken.None);
+
     // Recurring job for automatic changes indexation.
-    // It should push separate notification for each document type if any changes were indexed for this type
+    // It should push separate notification for each document type if any changes were indexed for this type.
+    // The IJobCancellationToken-flavored overload below is the Hangfire queue compatibility shim.
     [Queue(JobPriority.Normal)]
     [AutomaticRetry(Attempts = 0)]
     [DisableConcurrentExecution(10)]
@@ -143,6 +153,13 @@ public sealed class IndexingJobs : IIndexingJobService
             await RunIndexJobAsync(null, null, true, [options], IndexChangesAsync, context, cancellationToken);
         }
     }
+
+    [Queue(JobPriority.Normal)]
+    [AutomaticRetry(Attempts = 0)]
+    [DisableConcurrentExecution(10)]
+    [Obsolete("Hangfire compatibility shim for legacy queue items. Use the overload with CancellationToken.", DiagnosticId = "VC0014", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+    public Task IndexChangesJob(string documentType, PerformContext context, IJobCancellationToken cancellationToken)
+        => IndexChangesJob(documentType, context, cancellationToken?.ShutdownToken ?? CancellationToken.None);
 
 
     private static void EnqueueIndexDocuments(string documentType, string[] documentIds, string priority = JobPriority.Normal, IList<IIndexDocumentBuilder> builders = null)
@@ -242,8 +259,10 @@ public sealed class IndexingJobs : IIndexingJobService
         return result.GroupBy(x => x.Type);
     }
 
-    // Use hard-code methods to easily set queue for Hangfire.
-    // Make sure we wait for async methods to end, so that Hangfire retries if an exception occurs.
+    // Hard-coded one method per Hangfire queue so that [Queue] picks the right one at enqueue time.
+    // Each modern overload is followed by its [Obsolete] no-token shim that exists only to deserialize
+    // in-flight queue items left over from the pre-CancellationToken signature. New code MUST call
+    // the modern overload.
 
     [Queue(JobPriority.High)]
     public Task IndexDocumentsHighPriorityAsync(string documentType, string[] documentIds, IEnumerable<string> builderTypes, CancellationToken cancellationToken)
@@ -251,65 +270,16 @@ public sealed class IndexingJobs : IIndexingJobService
         return IndexDocumentsCoreAsync(documentType, documentIds, builderTypes, cancellationToken);
     }
 
+    [Queue(JobPriority.High)]
+    [Obsolete("Hangfire compatibility shim for legacy queue items. Use the overload with CancellationToken.", DiagnosticId = "VC0014", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+    public Task IndexDocumentsHighPriorityAsync(string documentType, string[] documentIds, IEnumerable<string> builderTypes)
+        => IndexDocumentsCoreAsync(documentType, documentIds, builderTypes, CancellationToken.None);
+
     [Queue(JobPriority.Normal)]
     public Task IndexDocumentsNormalPriorityAsync(string documentType, string[] documentIds, IEnumerable<string> builderTypes, CancellationToken cancellationToken)
     {
         return IndexDocumentsCoreAsync(documentType, documentIds, builderTypes, cancellationToken);
     }
-
-    [Queue(JobPriority.Low)]
-    public Task IndexDocumentsLowPriorityAsync(string documentType, string[] documentIds, IEnumerable<string> builderTypes, CancellationToken cancellationToken)
-    {
-        return IndexDocumentsCoreAsync(documentType, documentIds, builderTypes, cancellationToken);
-    }
-
-    [Queue(JobPriority.High)]
-    public Task DeleteDocumentsHighPriorityAsync(string documentType, string[] documentIds, CancellationToken cancellationToken)
-    {
-        return DeleteDocumentsCoreAsync(documentType, documentIds, cancellationToken);
-    }
-
-    [Queue(JobPriority.Normal)]
-    public Task DeleteDocumentsNormalPriorityAsync(string documentType, string[] documentIds, CancellationToken cancellationToken)
-    {
-        return DeleteDocumentsCoreAsync(documentType, documentIds, cancellationToken);
-    }
-
-    [Queue(JobPriority.Low)]
-    public Task DeleteDocumentsLowPriorityAsync(string documentType, string[] documentIds, CancellationToken cancellationToken)
-    {
-        return DeleteDocumentsCoreAsync(documentType, documentIds, cancellationToken);
-    }
-
-    // ----------------------------------------------------------------------
-    // Hangfire compatibility shims for in-flight queue items enqueued before
-    // the cancellation-aware overloads above were introduced. Hangfire identifies
-    // a job method by its parameter list; without these the upgrade would cause
-    // JobLoadException on dequeue. New code must NOT call these directly.
-    //
-    // The IJobCancellationToken-flavored shims of the public IndexAllDocumentsJob /
-    // IndexChangesJob entry points use IJobCancellationToken.ShutdownToken to bridge
-    // to the modern CancellationToken-based path. ShutdownToken only fires on server
-    // shutdown, not on Hangfire-side deletion, so jobs that flow through the shim
-    // remain less responsive to "Delete" until the queue has fully drained.
-    // ----------------------------------------------------------------------
-
-    [Queue(JobPriority.Normal)]
-    [Obsolete("Hangfire compatibility shim for legacy queue items. Use the overload with CancellationToken.", DiagnosticId = "VC0014", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
-    public Task IndexAllDocumentsJob(string userName, string notificationId, IndexingOptions[] options, PerformContext context, IJobCancellationToken cancellationToken)
-        => IndexAllDocumentsJob(userName, notificationId, options, context, cancellationToken?.ShutdownToken ?? CancellationToken.None);
-
-    [Queue(JobPriority.Normal)]
-    [AutomaticRetry(Attempts = 0)]
-    [DisableConcurrentExecution(10)]
-    [Obsolete("Hangfire compatibility shim for legacy queue items. Use the overload with CancellationToken.", DiagnosticId = "VC0014", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
-    public Task IndexChangesJob(string documentType, PerformContext context, IJobCancellationToken cancellationToken)
-        => IndexChangesJob(documentType, context, cancellationToken?.ShutdownToken ?? CancellationToken.None);
-
-    [Queue(JobPriority.High)]
-    [Obsolete("Hangfire compatibility shim for legacy queue items. Use the overload with CancellationToken.", DiagnosticId = "VC0014", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
-    public Task IndexDocumentsHighPriorityAsync(string documentType, string[] documentIds, IEnumerable<string> builderTypes)
-        => IndexDocumentsCoreAsync(documentType, documentIds, builderTypes, CancellationToken.None);
 
     [Queue(JobPriority.Normal)]
     [Obsolete("Hangfire compatibility shim for legacy queue items. Use the overload with CancellationToken.", DiagnosticId = "VC0014", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
@@ -317,9 +287,21 @@ public sealed class IndexingJobs : IIndexingJobService
         => IndexDocumentsCoreAsync(documentType, documentIds, builderTypes, CancellationToken.None);
 
     [Queue(JobPriority.Low)]
+    public Task IndexDocumentsLowPriorityAsync(string documentType, string[] documentIds, IEnumerable<string> builderTypes, CancellationToken cancellationToken)
+    {
+        return IndexDocumentsCoreAsync(documentType, documentIds, builderTypes, cancellationToken);
+    }
+
+    [Queue(JobPriority.Low)]
     [Obsolete("Hangfire compatibility shim for legacy queue items. Use the overload with CancellationToken.", DiagnosticId = "VC0014", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
     public Task IndexDocumentsLowPriorityAsync(string documentType, string[] documentIds, IEnumerable<string> builderTypes)
         => IndexDocumentsCoreAsync(documentType, documentIds, builderTypes, CancellationToken.None);
+
+    [Queue(JobPriority.High)]
+    public Task DeleteDocumentsHighPriorityAsync(string documentType, string[] documentIds, CancellationToken cancellationToken)
+    {
+        return DeleteDocumentsCoreAsync(documentType, documentIds, cancellationToken);
+    }
 
     [Queue(JobPriority.High)]
     [Obsolete("Hangfire compatibility shim for legacy queue items. Use the overload with CancellationToken.", DiagnosticId = "VC0014", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
@@ -327,9 +309,21 @@ public sealed class IndexingJobs : IIndexingJobService
         => DeleteDocumentsCoreAsync(documentType, documentIds, CancellationToken.None);
 
     [Queue(JobPriority.Normal)]
+    public Task DeleteDocumentsNormalPriorityAsync(string documentType, string[] documentIds, CancellationToken cancellationToken)
+    {
+        return DeleteDocumentsCoreAsync(documentType, documentIds, cancellationToken);
+    }
+
+    [Queue(JobPriority.Normal)]
     [Obsolete("Hangfire compatibility shim for legacy queue items. Use the overload with CancellationToken.", DiagnosticId = "VC0014", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
     public Task DeleteDocumentsNormalPriorityAsync(string documentType, string[] documentIds)
         => DeleteDocumentsCoreAsync(documentType, documentIds, CancellationToken.None);
+
+    [Queue(JobPriority.Low)]
+    public Task DeleteDocumentsLowPriorityAsync(string documentType, string[] documentIds, CancellationToken cancellationToken)
+    {
+        return DeleteDocumentsCoreAsync(documentType, documentIds, cancellationToken);
+    }
 
     [Queue(JobPriority.Low)]
     [Obsolete("Hangfire compatibility shim for legacy queue items. Use the overload with CancellationToken.", DiagnosticId = "VC0014", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]

--- a/src/VirtoCommerce.SearchModule.Data/BackgroundJobs/IndexingJobs.cs
+++ b/src/VirtoCommerce.SearchModule.Data/BackgroundJobs/IndexingJobs.cs
@@ -386,6 +386,12 @@ public sealed class IndexingJobs : IIndexingJobService
         PerformContext context,
         CancellationToken cancellationToken)
     {
+        // Materialize once. The parameter is typed as IEnumerable so callers could pass a deferred
+        // or one-shot iterator; we read it again from the catch block for cancellation logging,
+        // and we don't want re-enumeration to silently produce empty / different / side-effecting
+        // results. The `as` cast avoids an extra copy when an array is passed (the common case).
+        var optionsArray = allOptions as IndexingOptions[] ?? allOptions.ToArray();
+
         var success = false;
 
         // Reset progress handler to initial state
@@ -400,7 +406,7 @@ public sealed class IndexingJobs : IIndexingJobService
             {
                 try
                 {
-                    var tasks = allOptions.Select(x => indexationFunc(x, cancellationToken)).ToArray();
+                    var tasks = optionsArray.Select(x => indexationFunc(x, cancellationToken)).ToArray();
                     await Task.WhenAll(tasks);
 
                     success = true;
@@ -409,7 +415,7 @@ public sealed class IndexingJobs : IIndexingJobService
                 // AND Hangfire-side deletion; both surface as OperationCanceledException.
                 catch (OperationCanceledException)
                 {
-                    var documentTypes = string.Join(", ", allOptions.Select(o => o?.DocumentType ?? "<null>"));
+                    var documentTypes = string.Join(", ", optionsArray.Select(o => o?.DocumentType ?? "<null>"));
                     _log?.LogWarning("Indexing job {JobId} was cancelled. User: {UserName}, NotificationId: {NotificationId}, DocumentTypes: {DocumentTypes}",
                         context?.BackgroundJob?.Id, currentUserName, notificationId, documentTypes);
                     _progressHandler.Cancel();

--- a/src/VirtoCommerce.SearchModule.Data/BackgroundJobs/IndexingJobs.cs
+++ b/src/VirtoCommerce.SearchModule.Data/BackgroundJobs/IndexingJobs.cs
@@ -2,423 +2,528 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using Hangfire;
 using Hangfire.Server;
+using Microsoft.Extensions.Logging;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Jobs;
 using VirtoCommerce.Platform.Core.Settings;
-using VirtoCommerce.Platform.Hangfire;
 using VirtoCommerce.SearchModule.Core;
 using VirtoCommerce.SearchModule.Core.BackgroundJobs;
 using VirtoCommerce.SearchModule.Core.Model;
 using VirtoCommerce.SearchModule.Core.Services;
 
-namespace VirtoCommerce.SearchModule.Data.BackgroundJobs
+namespace VirtoCommerce.SearchModule.Data.BackgroundJobs;
+
+public sealed class IndexingJobs : IIndexingJobService
 {
-    public sealed class IndexingJobs : IIndexingJobService
+    private const string _recurringJobId = $"{nameof(IndexingJobs)}.{nameof(IndexChangesJob)}";
+    private static readonly MethodInfo _recurringJobMethod = typeof(IndexingJobs).GetMethod(nameof(IndexChangesJob), [typeof(string), typeof(PerformContext), typeof(CancellationToken)]);
+    private static readonly MethodInfo _manualJobMethod = typeof(IndexingJobs).GetMethod(nameof(IndexAllDocumentsJob), [typeof(string), typeof(string), typeof(IndexingOptions[]), typeof(PerformContext), typeof(CancellationToken)]);
+
+    private readonly IEnumerable<IndexDocumentConfiguration> _documentsConfigs;
+    private readonly IIndexingManager _indexingManager;
+    private readonly ISettingsManager _settingsManager;
+    private readonly IndexProgressHandler _progressHandler;
+    private readonly ILogger<IndexingJobs> _log;
+
+    public IndexingJobs(
+        IEnumerable<IndexDocumentConfiguration> documentsConfigs,
+        IIndexingManager indexingManager,
+        ISettingsManager settingsManager,
+        IndexProgressHandler progressHandler,
+        ILogger<IndexingJobs> log)
     {
-        private const string _recurringJobId = $"{nameof(IndexingJobs)}.{nameof(IndexChangesJob)}";
-        private static readonly MethodInfo _recurringJobMethod = typeof(IndexingJobs).GetMethod(nameof(IndexChangesJob));
-        private static readonly MethodInfo _manualJobMethod = typeof(IndexingJobs).GetMethod(nameof(IndexAllDocumentsJob));
+        _documentsConfigs = documentsConfigs;
+        _indexingManager = indexingManager;
+        _settingsManager = settingsManager;
+        _progressHandler = progressHandler;
+        _log = log;
+    }
 
-        private readonly IEnumerable<IndexDocumentConfiguration> _documentsConfigs;
-        private readonly IIndexingManager _indexingManager;
-        private readonly ISettingsManager _settingsManager;
-        private readonly IndexProgressHandler _progressHandler;
+    // Backwards-compatible constructor for callers that wired up IndexingJobs before the
+    // ILogger<IndexingJobs> parameter was introduced. Cancellation logging will be silently
+    // skipped when no logger is supplied; everything else continues to work.
+    [Obsolete("Use the constructor that accepts ILogger<IndexingJobs>.", DiagnosticId = "VC0014", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+    public IndexingJobs(
+        IEnumerable<IndexDocumentConfiguration> documentsConfigs,
+        IIndexingManager indexingManager,
+        ISettingsManager settingsManager,
+        IndexProgressHandler progressHandler)
+        : this(documentsConfigs, indexingManager, settingsManager, progressHandler, log: null)
+    {
+    }
 
-        public IndexingJobs(
-            IEnumerable<IndexDocumentConfiguration> documentsConfigs,
-            IIndexingManager indexingManager,
-            ISettingsManager settingsManager,
-            IndexProgressHandler progressHandler)
+    // Enqueue a background job with single notification object for all given options
+    public IndexProgressPushNotification Enqueue(string currentUserName, IndexingOptions[] options)
+    {
+        var notification = IndexProgressHandler.CreateNotification(currentUserName, null);
+
+        // Hangfire substitutes CancellationToken.None with a real token at execution time.
+        notification.JobId = BackgroundJob.Enqueue<IndexingJobs>(j => j.IndexAllDocumentsJob(currentUserName, notification.Id, options, null, CancellationToken.None));
+
+        return notification;
+    }
+
+    public async Task StartStopRecurringJobs()
+    {
+        var scheduleJobs = await _settingsManager.GetValueAsync<bool>(ModuleConstants.Settings.IndexingJobs.Enable);
+
+        if (scheduleJobs)
         {
-            _documentsConfigs = documentsConfigs;
-            _indexingManager = indexingManager;
-            _settingsManager = settingsManager;
-            _progressHandler = progressHandler;
+            var cronExpression = await _settingsManager.GetValueAsync<string>(ModuleConstants.Settings.IndexingJobs.CronExpression);
+            RecurringJob.AddOrUpdate<IndexingJobs>(_recurringJobId, x => x.IndexChangesJob(null, null, CancellationToken.None), cronExpression);
         }
-
-        // Enqueue a background job with single notification object for all given options
-        public IndexProgressPushNotification Enqueue(string currentUserName, IndexingOptions[] options)
+        else
         {
-            var notification = IndexProgressHandler.CreateNotification(currentUserName, null);
-
-            // Hangfire will set cancellation token.
-            notification.JobId = BackgroundJob.Enqueue<IndexingJobs>(j => j.IndexAllDocumentsJob(currentUserName, notification.Id, options, null, JobCancellationToken.Null));
-
-            return notification;
+            CancelJob(_recurringJobMethod);
+            RecurringJob.RemoveIfExists(_recurringJobId);
         }
+    }
 
-        public async Task StartStopRecurringJobs()
-        {
-            var scheduleJobs = await _settingsManager.GetValueAsync<bool>(ModuleConstants.Settings.IndexingJobs.Enable);
+    // Cancel current indexation if there is one
+    public void CancelIndexation()
+    {
+        CancelJob(_manualJobMethod);
+    }
 
-            if (scheduleJobs)
-            {
-                var cronExpression = await _settingsManager.GetValueAsync<string>(ModuleConstants.Settings.IndexingJobs.CronExpression);
-                RecurringJob.AddOrUpdate<IndexingJobs>(_recurringJobId, x => x.IndexChangesJob(null, null, JobCancellationToken.Null), cronExpression);
-            }
-            else
-            {
-                CancelJob(_recurringJobMethod);
-                RecurringJob.RemoveIfExists(_recurringJobId);
-            }
-        }
+    private static void CancelJob(MethodInfo method)
+    {
+        var processingJobs = JobStorage.Current.GetMonitoringApi().ProcessingJobs(0, int.MaxValue);
 
-        // Cancel current indexation if there is one
-        public void CancelIndexation()
-        {
-            CancelJob(_manualJobMethod);
-        }
+        // Match by name + declaring type (rather than by exact MethodInfo reference) so that
+        // jobs running through the [Obsolete] IJobCancellationToken-flavored shim overloads
+        // are also cancelled. Hangfire treats each overload as a distinct method.
+        var (jobId, _) = processingJobs.FirstOrDefault(x =>
+            x.Value?.Job?.Method is { } running &&
+            running.DeclaringType == method.DeclaringType &&
+            running.Name == method.Name);
 
-        private static void CancelJob(MethodInfo method)
-        {
-            var processingJobs = JobStorage.Current.GetMonitoringApi().ProcessingJobs(0, int.MaxValue);
-            var (jobId, _) = processingJobs.FirstOrDefault(x => x.Value?.Job?.Method == method);
-
-            if (!string.IsNullOrEmpty(jobId))
-            {
-                try
-                {
-                    BackgroundJob.Delete(jobId);
-                }
-                catch
-                {
-                    // Ignore concurrency exceptions, when somebody else cancelled it as well.
-                }
-            }
-        }
-
-
-        // One-time job for manual indexation
-        [Queue(JobPriority.Normal)]
-        public async Task IndexAllDocumentsJob(string userName, string notificationId, IndexingOptions[] options, PerformContext context, IJobCancellationToken cancellationToken)
+        if (!string.IsNullOrEmpty(jobId))
         {
             try
             {
-                await RunIndexJobAsync(userName, notificationId, false, options, IndexAllDocumentsAsync, context, cancellationToken);
-            }
-            finally
-            {
-                // Report indexation summary
-                _progressHandler.Finish();
-            }
-        }
-
-        // Recurring job for automatic changes indexation.
-        // It should push separate notification for each document type if any changes were indexed for this type
-        [Queue(JobPriority.Normal)]
-        [AutomaticRetry(Attempts = 0)]
-        [DisableConcurrentExecution(10)]
-        public async Task IndexChangesJob(string documentType, PerformContext context, IJobCancellationToken cancellationToken)
-        {
-            var allOptions = await GetAllIndexingOptionsAsync(documentType);
-            foreach (var options in allOptions)
-            {
-                await RunIndexJobAsync(null, null, true, [options], IndexChangesAsync, context, cancellationToken);
-            }
-        }
-
-
-        private static void EnqueueIndexDocuments(string documentType, string[] documentIds, string priority = JobPriority.Normal, IList<IIndexDocumentBuilder> builders = null)
-        {
-            var buildersTypes = builders?.Select(x => x.GetType().FullName);
-
-            switch (priority)
-            {
-                case JobPriority.High:
-                    BackgroundJob.Enqueue<IndexingJobs>(x => x.IndexDocumentsHighPriorityAsync(documentType, documentIds, buildersTypes));
-                    break;
-                case JobPriority.Normal:
-                    BackgroundJob.Enqueue<IndexingJobs>(x => x.IndexDocumentsNormalPriorityAsync(documentType, documentIds, buildersTypes));
-                    break;
-                case JobPriority.Low:
-                    BackgroundJob.Enqueue<IndexingJobs>(x => x.IndexDocumentsLowPriorityAsync(documentType, documentIds, buildersTypes));
-                    break;
-                default:
-                    throw new ArgumentException($"Unknown priority: {priority}", nameof(priority));
-            }
-        }
-
-        private static void EnqueueDeleteDocuments(string documentType, string[] documentIds, string priority = JobPriority.Normal)
-        {
-            switch (priority)
-            {
-                case JobPriority.High:
-                    BackgroundJob.Enqueue<IndexingJobs>(x => x.DeleteDocumentsHighPriorityAsync(documentType, documentIds));
-                    break;
-                case JobPriority.Normal:
-                    BackgroundJob.Enqueue<IndexingJobs>(x => x.DeleteDocumentsNormalPriorityAsync(documentType, documentIds));
-                    break;
-                case JobPriority.Low:
-                    BackgroundJob.Enqueue<IndexingJobs>(x => x.DeleteDocumentsLowPriorityAsync(documentType, documentIds));
-                    break;
-                default:
-                    throw new ArgumentException($"Unknown priority: {priority}", nameof(priority));
-            }
-        }
-
-        public void EnqueueIndexAndDeleteDocuments(IList<IndexEntry> indexEntries, string priority = JobPriority.Normal, IList<IIndexDocumentBuilder> builders = null)
-        {
-            var groupedEntriesByType = GetGroupedByTypeAndDistinctedByChangeTypeIndexEntries(indexEntries);
-
-            foreach (var groupedEntryByType in groupedEntriesByType)
-            {
-                var addedEntryIds = groupedEntryByType.Where(x => x.EntryState == EntryState.Added).Select(x => x.Id).ToArray();
-                var modifiedEntryIds = groupedEntryByType.Where(x => x.EntryState == EntryState.Modified).Select(x => x.Id).ToArray();
-                var deletedEntryIds = groupedEntryByType.Where(x => x.EntryState == EntryState.Deleted).Select(x => x.Id).ToArray();
-
-                if (addedEntryIds.Length > 0)
-                {
-                    EnqueueIndexDocuments(groupedEntryByType.Key, addedEntryIds, priority, builders: null);
-                }
-
-                if (modifiedEntryIds.Length > 0)
-                {
-                    EnqueueIndexDocuments(groupedEntryByType.Key, modifiedEntryIds, priority, builders);
-                }
-
-                if (deletedEntryIds.Length > 0)
-                {
-                    EnqueueDeleteDocuments(groupedEntryByType.Key, deletedEntryIds, priority);
-                }
-            }
-        }
-
-        public static IEnumerable<IGrouping<string, IndexEntry>> GetGroupedByTypeAndDistinctedByChangeTypeIndexEntries(IEnumerable<IndexEntry> indexEntries)
-        {
-            var indexEntriesFilteredFromEmptyIds = indexEntries.Where(x => !string.IsNullOrEmpty(x.Id));
-
-            var result = new List<IndexEntry>();
-
-            foreach (var indexEntryGroupedByType in indexEntriesFilteredFromEmptyIds.GroupBy(x => x.Type))
-            {
-                foreach (var indexEntryGroupedById in indexEntryGroupedByType.GroupBy(x => x.Id))
-                {
-                    var entryWasAdded = indexEntryGroupedById.Any(x => x.EntryState is EntryState.Added);
-                    var entryWasModified = indexEntryGroupedById.Any(x => x.EntryState is EntryState.Modified);
-                    var entryWasDeleted = indexEntryGroupedById.Any(x => x.EntryState is EntryState.Deleted);
-
-                    if (entryWasDeleted)
-                    {
-                        result.Add(indexEntryGroupedById.First(x => x.EntryState is EntryState.Deleted));
-                    }
-                    else if (entryWasAdded)
-                    {
-                        result.Add(indexEntryGroupedById.First(x => x.EntryState is EntryState.Added));
-                    }
-                    else if (entryWasModified)
-                    {
-                        result.Add(indexEntryGroupedById.First(x => x.EntryState is EntryState.Modified));
-                    }
-                }
-            }
-
-            return result.GroupBy(x => x.Type);
-        }
-
-        // Use hard-code methods to easily set queue for Hangfire.
-        // Make sure we wait for async methods to end, so that Hangfire retries if an exception occurs.
-
-        [Queue(JobPriority.High)]
-        public async Task IndexDocumentsHighPriorityAsync(string documentType, string[] documentIds, IEnumerable<string> builderTypes)
-        {
-            if (!documentIds.IsNullOrEmpty())
-            {
-                await _indexingManager.IndexDocumentsAsync(documentType, documentIds, builderTypes);
-            }
-        }
-
-        [Queue(JobPriority.Normal)]
-        public async Task IndexDocumentsNormalPriorityAsync(string documentType, string[] documentIds, IEnumerable<string> builderTypes)
-        {
-            if (!documentIds.IsNullOrEmpty())
-            {
-                await _indexingManager.IndexDocumentsAsync(documentType, documentIds, builderTypes);
-            }
-        }
-
-        [Queue(JobPriority.Low)]
-        public async Task IndexDocumentsLowPriorityAsync(string documentType, string[] documentIds, IEnumerable<string> builderTypes)
-        {
-            if (!documentIds.IsNullOrEmpty())
-            {
-                await _indexingManager.IndexDocumentsAsync(documentType, documentIds, builderTypes);
-            }
-        }
-
-        [Queue(JobPriority.High)]
-        public async Task DeleteDocumentsHighPriorityAsync(string documentType, string[] documentIds)
-        {
-            if (!documentIds.IsNullOrEmpty())
-            {
-                await _indexingManager.DeleteDocumentsAsync(documentType, documentIds);
-            }
-        }
-
-        [Queue(JobPriority.Normal)]
-        public async Task DeleteDocumentsNormalPriorityAsync(string documentType, string[] documentIds)
-        {
-            if (!documentIds.IsNullOrEmpty())
-            {
-                await _indexingManager.DeleteDocumentsAsync(documentType, documentIds);
-            }
-        }
-
-        [Queue(JobPriority.Low)]
-        public async Task DeleteDocumentsLowPriorityAsync(string documentType, string[] documentIds)
-        {
-            if (!documentIds.IsNullOrEmpty())
-            {
-                await _indexingManager.DeleteDocumentsAsync(documentType, documentIds);
-            }
-        }
-
-
-        private async Task<bool> RunIndexJobAsync(
-            string currentUserName,
-            string notificationId,
-            bool suppressInsignificantNotifications,
-            IEnumerable<IndexingOptions> allOptions,
-            Func<IndexingOptions, ICancellationToken, Task> indexationFunc,
-            PerformContext context,
-            IJobCancellationToken cancellationToken)
-        {
-            var success = false;
-
-            // Reset progress handler to initial state
-            _progressHandler.Start(currentUserName, notificationId, suppressInsignificantNotifications, context);
-
-            // Make sure only one indexation job can run in the cluster.
-            // CAUTION: locking mechanism assumes single threaded execution.
-            try
-            {
-                using var connection = JobStorage.Current.GetConnection();
-                using (connection.AcquireDistributedLock("IndexationJob", TimeSpan.Zero))
-                {
-                    try
-                    {
-                        var tasks = allOptions.Select(x => indexationFunc(x, new JobCancellationTokenWrapper(cancellationToken))).ToArray();
-                        await Task.WhenAll(tasks);
-
-                        success = true;
-                    }
-                    catch (OperationCanceledException)
-                    {
-                        _progressHandler.Cancel();
-                    }
-                    catch (Exception ex)
-                    {
-                        _progressHandler.Exception(ex);
-                    }
-                    finally
-                    {
-                        // Report indexation summary only for "Recurring job for automatic changes indexation."
-                        if (notificationId.IsNullOrEmpty())
-                        {
-                            _progressHandler.Finish();
-                        }
-                    }
-                }
+                BackgroundJob.Delete(jobId);
             }
             catch
             {
-                // TODO: Check wait in calling method
-                _progressHandler.AlreadyInProgress();
+                // Ignore concurrency exceptions, when somebody else cancelled it as well.
+            }
+        }
+    }
+
+
+    // One-time job for manual indexation
+    [Queue(JobPriority.Normal)]
+    public async Task IndexAllDocumentsJob(string userName, string notificationId, IndexingOptions[] options, PerformContext context, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await RunIndexJobAsync(userName, notificationId, false, options, IndexAllDocumentsAsync, context, cancellationToken);
+        }
+        finally
+        {
+            // Report indexation summary
+            _progressHandler.Finish();
+        }
+    }
+
+    // Recurring job for automatic changes indexation.
+    // It should push separate notification for each document type if any changes were indexed for this type
+    [Queue(JobPriority.Normal)]
+    [AutomaticRetry(Attempts = 0)]
+    [DisableConcurrentExecution(10)]
+    public async Task IndexChangesJob(string documentType, PerformContext context, CancellationToken cancellationToken)
+    {
+        var allOptions = await GetAllIndexingOptionsAsync(documentType);
+        foreach (var options in allOptions)
+        {
+            await RunIndexJobAsync(null, null, true, [options], IndexChangesAsync, context, cancellationToken);
+        }
+    }
+
+
+    private static void EnqueueIndexDocuments(string documentType, string[] documentIds, string priority = JobPriority.Normal, IList<IIndexDocumentBuilder> builders = null)
+    {
+        var buildersTypes = builders?.Select(x => x.GetType().FullName);
+
+        switch (priority)
+        {
+            case JobPriority.High:
+                BackgroundJob.Enqueue<IndexingJobs>(x => x.IndexDocumentsHighPriorityAsync(documentType, documentIds, buildersTypes, CancellationToken.None));
+                break;
+            case JobPriority.Normal:
+                BackgroundJob.Enqueue<IndexingJobs>(x => x.IndexDocumentsNormalPriorityAsync(documentType, documentIds, buildersTypes, CancellationToken.None));
+                break;
+            case JobPriority.Low:
+                BackgroundJob.Enqueue<IndexingJobs>(x => x.IndexDocumentsLowPriorityAsync(documentType, documentIds, buildersTypes, CancellationToken.None));
+                break;
+            default:
+                throw new ArgumentException($"Unknown priority: {priority}", nameof(priority));
+        }
+    }
+
+    private static void EnqueueDeleteDocuments(string documentType, string[] documentIds, string priority = JobPriority.Normal)
+    {
+        switch (priority)
+        {
+            case JobPriority.High:
+                BackgroundJob.Enqueue<IndexingJobs>(x => x.DeleteDocumentsHighPriorityAsync(documentType, documentIds, CancellationToken.None));
+                break;
+            case JobPriority.Normal:
+                BackgroundJob.Enqueue<IndexingJobs>(x => x.DeleteDocumentsNormalPriorityAsync(documentType, documentIds, CancellationToken.None));
+                break;
+            case JobPriority.Low:
+                BackgroundJob.Enqueue<IndexingJobs>(x => x.DeleteDocumentsLowPriorityAsync(documentType, documentIds, CancellationToken.None));
+                break;
+            default:
+                throw new ArgumentException($"Unknown priority: {priority}", nameof(priority));
+        }
+    }
+
+    public void EnqueueIndexAndDeleteDocuments(IList<IndexEntry> indexEntries, string priority = JobPriority.Normal, IList<IIndexDocumentBuilder> builders = null)
+    {
+        var groupedEntriesByType = GetGroupedByTypeAndDistinctedByChangeTypeIndexEntries(indexEntries);
+
+        foreach (var groupedEntryByType in groupedEntriesByType)
+        {
+            var addedEntryIds = groupedEntryByType.Where(x => x.EntryState == EntryState.Added).Select(x => x.Id).ToArray();
+            var modifiedEntryIds = groupedEntryByType.Where(x => x.EntryState == EntryState.Modified).Select(x => x.Id).ToArray();
+            var deletedEntryIds = groupedEntryByType.Where(x => x.EntryState == EntryState.Deleted).Select(x => x.Id).ToArray();
+
+            if (addedEntryIds.Length > 0)
+            {
+                EnqueueIndexDocuments(groupedEntryByType.Key, addedEntryIds, priority, builders: null);
             }
 
-            return success;
-        }
-
-        private async Task IndexAllDocumentsAsync(IndexingOptions options, ICancellationToken cancellationToken)
-        {
-            var oldIndexationDate = await GetLastIndexationDateAsync(options.DocumentType);
-            var newIndexationDate = DateTime.UtcNow;
-
-            await _indexingManager.IndexAllDocumentsAsync(options, _progressHandler.Progress, cancellationToken);
-
-            // Save indexation date to prevent changes from being indexed again
-            await SetLastIndexationDateAsync(options.DocumentType, oldIndexationDate, newIndexationDate);
-        }
-
-        private async Task IndexChangesAsync(IndexingOptions options, ICancellationToken cancellationToken)
-        {
-            var oldIndexationDate = options.StartDate;
-            var newIndexationDate = DateTime.UtcNow;
-
-            options.EndDate = oldIndexationDate == null ? null : newIndexationDate;
-
-            await _indexingManager.IndexChangesAsync(options, _progressHandler.Progress, cancellationToken);
-
-            // Save indexation date. It will be used as a start date for the next indexation
-            await SetLastIndexationDateAsync(options.DocumentType, oldIndexationDate, newIndexationDate);
-        }
-
-        private async Task<IList<IndexingOptions>> GetAllIndexingOptionsAsync(string documentType)
-        {
-            var configs = _documentsConfigs;
-
-            if (!string.IsNullOrEmpty(documentType))
+            if (modifiedEntryIds.Length > 0)
             {
-                configs = configs.Where(c => c.DocumentType.EqualsIgnoreCase(documentType));
+                EnqueueIndexDocuments(groupedEntryByType.Key, modifiedEntryIds, priority, builders);
             }
 
-            var tasks = configs.Select(x => GetIndexingOptionsAsync(x.DocumentType)).ToArray();
-            var result = await Task.WhenAll(tasks);
-
-            return result;
-        }
-
-        private async Task<IndexingOptions> GetIndexingOptionsAsync(string documentType)
-        {
-            return new IndexingOptions
+            if (deletedEntryIds.Length > 0)
             {
-                DocumentType = documentType,
-                DeleteExistingIndex = false,
-                StartDate = await GetLastIndexationDateAsync(documentType),
-                BatchSize = await GetBatchSizeAsync(),
-            };
+                EnqueueDeleteDocuments(groupedEntryByType.Key, deletedEntryIds, priority);
+            }
         }
+    }
 
-        private async Task<DateTime?> GetLastIndexationDateAsync(string documentType)
+    public static IEnumerable<IGrouping<string, IndexEntry>> GetGroupedByTypeAndDistinctedByChangeTypeIndexEntries(IEnumerable<IndexEntry> indexEntries)
+    {
+        var indexEntriesFilteredFromEmptyIds = indexEntries.Where(x => !string.IsNullOrEmpty(x.Id));
+
+        var result = new List<IndexEntry>();
+
+        foreach (var indexEntryGroupedByType in indexEntriesFilteredFromEmptyIds.GroupBy(x => x.Type))
         {
-            var result = (await _indexingManager.GetIndexStateAsync(documentType)).LastIndexationDate;
-            if (result != null)
+            foreach (var indexEntryGroupedById in indexEntryGroupedByType.GroupBy(x => x.Id))
             {
-                var settingDescriptor = new SettingDescriptor
+                var entryWasAdded = indexEntryGroupedById.Any(x => x.EntryState is EntryState.Added);
+                var entryWasModified = indexEntryGroupedById.Any(x => x.EntryState is EntryState.Modified);
+                var entryWasDeleted = indexEntryGroupedById.Any(x => x.EntryState is EntryState.Deleted);
+
+                if (entryWasDeleted)
                 {
-                    Name = GetLastIndexationDateName(documentType),
-                    ValueType = SettingValueType.DateTime,
-                    DefaultValue = DateTime.MaxValue,
-                };
-
-                //need to take the older date from the dates loaded from the index and settings.
-                //Because the actual last indexation date stored in the index may be later than last job run are stored in the settings. e.g. after data import or direct database changes
-                var settingValue = await _settingsManager.GetValueAsync<DateTime>(settingDescriptor);
-                result = new DateTime(Math.Min(result.Value.Ticks, settingValue.Ticks), DateTimeKind.Utc);
+                    result.Add(indexEntryGroupedById.First(x => x.EntryState is EntryState.Deleted));
+                }
+                else if (entryWasAdded)
+                {
+                    result.Add(indexEntryGroupedById.First(x => x.EntryState is EntryState.Added));
+                }
+                else if (entryWasModified)
+                {
+                    result.Add(indexEntryGroupedById.First(x => x.EntryState is EntryState.Modified));
+                }
             }
-
-            return result;
         }
 
-        private async Task SetLastIndexationDateAsync(string documentType, DateTime? oldValue, DateTime newValue)
+        return result.GroupBy(x => x.Type);
+    }
+
+    // Use hard-code methods to easily set queue for Hangfire.
+    // Make sure we wait for async methods to end, so that Hangfire retries if an exception occurs.
+
+    [Queue(JobPriority.High)]
+    public Task IndexDocumentsHighPriorityAsync(string documentType, string[] documentIds, IEnumerable<string> builderTypes, CancellationToken cancellationToken)
+    {
+        return IndexDocumentsCoreAsync(documentType, documentIds, builderTypes, cancellationToken);
+    }
+
+    [Queue(JobPriority.Normal)]
+    public Task IndexDocumentsNormalPriorityAsync(string documentType, string[] documentIds, IEnumerable<string> builderTypes, CancellationToken cancellationToken)
+    {
+        return IndexDocumentsCoreAsync(documentType, documentIds, builderTypes, cancellationToken);
+    }
+
+    [Queue(JobPriority.Low)]
+    public Task IndexDocumentsLowPriorityAsync(string documentType, string[] documentIds, IEnumerable<string> builderTypes, CancellationToken cancellationToken)
+    {
+        return IndexDocumentsCoreAsync(documentType, documentIds, builderTypes, cancellationToken);
+    }
+
+    [Queue(JobPriority.High)]
+    public Task DeleteDocumentsHighPriorityAsync(string documentType, string[] documentIds, CancellationToken cancellationToken)
+    {
+        return DeleteDocumentsCoreAsync(documentType, documentIds, cancellationToken);
+    }
+
+    [Queue(JobPriority.Normal)]
+    public Task DeleteDocumentsNormalPriorityAsync(string documentType, string[] documentIds, CancellationToken cancellationToken)
+    {
+        return DeleteDocumentsCoreAsync(documentType, documentIds, cancellationToken);
+    }
+
+    [Queue(JobPriority.Low)]
+    public Task DeleteDocumentsLowPriorityAsync(string documentType, string[] documentIds, CancellationToken cancellationToken)
+    {
+        return DeleteDocumentsCoreAsync(documentType, documentIds, cancellationToken);
+    }
+
+    // ----------------------------------------------------------------------
+    // Hangfire compatibility shims for in-flight queue items enqueued before
+    // the cancellation-aware overloads above were introduced. Hangfire identifies
+    // a job method by its parameter list; without these the upgrade would cause
+    // JobLoadException on dequeue. New code must NOT call these directly.
+    //
+    // The IJobCancellationToken-flavored shims of the public IndexAllDocumentsJob /
+    // IndexChangesJob entry points use IJobCancellationToken.ShutdownToken to bridge
+    // to the modern CancellationToken-based path. ShutdownToken only fires on server
+    // shutdown, not on Hangfire-side deletion, so jobs that flow through the shim
+    // remain less responsive to "Delete" until the queue has fully drained.
+    // ----------------------------------------------------------------------
+
+    [Queue(JobPriority.Normal)]
+    [Obsolete("Hangfire compatibility shim for legacy queue items. Use the overload with CancellationToken.", DiagnosticId = "VC0014", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+    public Task IndexAllDocumentsJob(string userName, string notificationId, IndexingOptions[] options, PerformContext context, IJobCancellationToken cancellationToken)
+        => IndexAllDocumentsJob(userName, notificationId, options, context, cancellationToken?.ShutdownToken ?? CancellationToken.None);
+
+    [Queue(JobPriority.Normal)]
+    [AutomaticRetry(Attempts = 0)]
+    [DisableConcurrentExecution(10)]
+    [Obsolete("Hangfire compatibility shim for legacy queue items. Use the overload with CancellationToken.", DiagnosticId = "VC0014", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+    public Task IndexChangesJob(string documentType, PerformContext context, IJobCancellationToken cancellationToken)
+        => IndexChangesJob(documentType, context, cancellationToken?.ShutdownToken ?? CancellationToken.None);
+
+    [Queue(JobPriority.High)]
+    [Obsolete("Hangfire compatibility shim for legacy queue items. Use the overload with CancellationToken.", DiagnosticId = "VC0014", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+    public Task IndexDocumentsHighPriorityAsync(string documentType, string[] documentIds, IEnumerable<string> builderTypes)
+        => IndexDocumentsCoreAsync(documentType, documentIds, builderTypes, CancellationToken.None);
+
+    [Queue(JobPriority.Normal)]
+    [Obsolete("Hangfire compatibility shim for legacy queue items. Use the overload with CancellationToken.", DiagnosticId = "VC0014", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+    public Task IndexDocumentsNormalPriorityAsync(string documentType, string[] documentIds, IEnumerable<string> builderTypes)
+        => IndexDocumentsCoreAsync(documentType, documentIds, builderTypes, CancellationToken.None);
+
+    [Queue(JobPriority.Low)]
+    [Obsolete("Hangfire compatibility shim for legacy queue items. Use the overload with CancellationToken.", DiagnosticId = "VC0014", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+    public Task IndexDocumentsLowPriorityAsync(string documentType, string[] documentIds, IEnumerable<string> builderTypes)
+        => IndexDocumentsCoreAsync(documentType, documentIds, builderTypes, CancellationToken.None);
+
+    [Queue(JobPriority.High)]
+    [Obsolete("Hangfire compatibility shim for legacy queue items. Use the overload with CancellationToken.", DiagnosticId = "VC0014", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+    public Task DeleteDocumentsHighPriorityAsync(string documentType, string[] documentIds)
+        => DeleteDocumentsCoreAsync(documentType, documentIds, CancellationToken.None);
+
+    [Queue(JobPriority.Normal)]
+    [Obsolete("Hangfire compatibility shim for legacy queue items. Use the overload with CancellationToken.", DiagnosticId = "VC0014", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+    public Task DeleteDocumentsNormalPriorityAsync(string documentType, string[] documentIds)
+        => DeleteDocumentsCoreAsync(documentType, documentIds, CancellationToken.None);
+
+    [Queue(JobPriority.Low)]
+    [Obsolete("Hangfire compatibility shim for legacy queue items. Use the overload with CancellationToken.", DiagnosticId = "VC0014", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+    public Task DeleteDocumentsLowPriorityAsync(string documentType, string[] documentIds)
+        => DeleteDocumentsCoreAsync(documentType, documentIds, CancellationToken.None);
+
+    private async Task IndexDocumentsCoreAsync(string documentType, string[] documentIds, IEnumerable<string> builderTypes, CancellationToken cancellationToken)
+    {
+        if (documentIds.IsNullOrEmpty())
         {
-            var currentValue = await GetLastIndexationDateAsync(documentType);
-            if (currentValue == oldValue)
+            return;
+        }
+
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await _indexingManager.IndexDocumentsAsync(documentType, documentIds, builderTypes, cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            _log?.LogWarning("Bulk index job was cancelled. DocumentType: {DocumentType}, DocumentCount: {DocumentCount}",
+                documentType, documentIds.Length);
+            throw;
+        }
+    }
+
+    private async Task DeleteDocumentsCoreAsync(string documentType, string[] documentIds, CancellationToken cancellationToken)
+    {
+        if (documentIds.IsNullOrEmpty())
+        {
+            return;
+        }
+
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await _indexingManager.DeleteDocumentsAsync(documentType, documentIds, cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            _log?.LogWarning("Bulk delete job was cancelled. DocumentType: {DocumentType}, DocumentCount: {DocumentCount}",
+                documentType, documentIds.Length);
+            throw;
+        }
+    }
+
+
+    private async Task<bool> RunIndexJobAsync(
+        string currentUserName,
+        string notificationId,
+        bool suppressInsignificantNotifications,
+        IEnumerable<IndexingOptions> allOptions,
+        Func<IndexingOptions, CancellationToken, Task> indexationFunc,
+        PerformContext context,
+        CancellationToken cancellationToken)
+    {
+        var success = false;
+
+        // Reset progress handler to initial state
+        _progressHandler.Start(currentUserName, notificationId, suppressInsignificantNotifications, context);
+
+        // Make sure only one indexation job can run in the cluster.
+        // CAUTION: locking mechanism assumes single threaded execution.
+        try
+        {
+            using var connection = JobStorage.Current.GetConnection();
+            using (connection.AcquireDistributedLock("IndexationJob", TimeSpan.Zero))
             {
-                await _settingsManager.SetValueAsync(GetLastIndexationDateName(documentType), newValue);
+                try
+                {
+                    var tasks = allOptions.Select(x => indexationFunc(x, cancellationToken)).ToArray();
+                    await Task.WhenAll(tasks);
+
+                    success = true;
+                }
+                // Hangfire 1.7+ injects a CancellationToken that fires on both server shutdown
+                // AND Hangfire-side deletion; both surface as OperationCanceledException.
+                catch (OperationCanceledException)
+                {
+                    var documentTypes = string.Join(", ", allOptions.Select(o => o?.DocumentType ?? "<null>"));
+                    _log?.LogWarning("Indexing job {JobId} was cancelled. User: {UserName}, NotificationId: {NotificationId}, DocumentTypes: {DocumentTypes}",
+                        context?.BackgroundJob?.Id, currentUserName, notificationId, documentTypes);
+                    _progressHandler.Cancel();
+                }
+                catch (Exception ex)
+                {
+                    _progressHandler.Exception(ex);
+                }
+                finally
+                {
+                    // Report indexation summary only for "Recurring job for automatic changes indexation."
+                    if (notificationId.IsNullOrEmpty())
+                    {
+                        _progressHandler.Finish();
+                    }
+                }
             }
         }
-
-        private static string GetLastIndexationDateName(string documentType)
+        catch
         {
-            return $"VirtoCommerce.Search.IndexingJobs.IndexationDate.{documentType}";
+            // TODO: Check wait in calling method
+            _progressHandler.AlreadyInProgress();
         }
 
-        private Task<int> GetBatchSizeAsync()
+        return success;
+    }
+
+    private async Task IndexAllDocumentsAsync(IndexingOptions options, CancellationToken cancellationToken)
+    {
+        var oldIndexationDate = await GetLastIndexationDateAsync(options.DocumentType);
+        var newIndexationDate = DateTime.UtcNow;
+
+        await _indexingManager.IndexAllDocumentsAsync(options, _progressHandler.Progress, cancellationToken);
+
+        // Save indexation date to prevent changes from being indexed again
+        await SetLastIndexationDateAsync(options.DocumentType, oldIndexationDate, newIndexationDate);
+    }
+
+    private async Task IndexChangesAsync(IndexingOptions options, CancellationToken cancellationToken)
+    {
+        var oldIndexationDate = options.StartDate;
+        var newIndexationDate = DateTime.UtcNow;
+
+        options.EndDate = oldIndexationDate == null ? null : newIndexationDate;
+
+        await _indexingManager.IndexChangesAsync(options, _progressHandler.Progress, cancellationToken);
+
+        // Save indexation date. It will be used as a start date for the next indexation
+        await SetLastIndexationDateAsync(options.DocumentType, oldIndexationDate, newIndexationDate);
+    }
+
+    private async Task<IList<IndexingOptions>> GetAllIndexingOptionsAsync(string documentType)
+    {
+        var configs = _documentsConfigs;
+
+        if (!string.IsNullOrEmpty(documentType))
         {
-            return _settingsManager.GetValueAsync<int>(ModuleConstants.Settings.General.IndexPartitionSize);
+            configs = configs.Where(c => c.DocumentType.EqualsIgnoreCase(documentType));
         }
+
+        var tasks = configs.Select(x => GetIndexingOptionsAsync(x.DocumentType)).ToArray();
+        var result = await Task.WhenAll(tasks);
+
+        return result;
+    }
+
+    private async Task<IndexingOptions> GetIndexingOptionsAsync(string documentType)
+    {
+        return new IndexingOptions
+        {
+            DocumentType = documentType,
+            DeleteExistingIndex = false,
+            StartDate = await GetLastIndexationDateAsync(documentType),
+            BatchSize = await GetBatchSizeAsync(),
+        };
+    }
+
+    private async Task<DateTime?> GetLastIndexationDateAsync(string documentType)
+    {
+        var result = (await _indexingManager.GetIndexStateAsync(documentType)).LastIndexationDate;
+        if (result != null)
+        {
+            var settingDescriptor = new SettingDescriptor
+            {
+                Name = GetLastIndexationDateName(documentType),
+                ValueType = SettingValueType.DateTime,
+                DefaultValue = DateTime.MaxValue,
+            };
+
+            //need to take the older date from the dates loaded from the index and settings.
+            //Because the actual last indexation date stored in the index may be later than last job run are stored in the settings. e.g. after data import or direct database changes
+            var settingValue = await _settingsManager.GetValueAsync<DateTime>(settingDescriptor);
+            result = new DateTime(Math.Min(result.Value.Ticks, settingValue.Ticks), DateTimeKind.Utc);
+        }
+
+        return result;
+    }
+
+    private async Task SetLastIndexationDateAsync(string documentType, DateTime? oldValue, DateTime newValue)
+    {
+        var currentValue = await GetLastIndexationDateAsync(documentType);
+        if (currentValue == oldValue)
+        {
+            await _settingsManager.SetValueAsync(GetLastIndexationDateName(documentType), newValue);
+        }
+    }
+
+    private static string GetLastIndexationDateName(string documentType)
+    {
+        return $"VirtoCommerce.Search.IndexingJobs.IndexationDate.{documentType}";
+    }
+
+    private Task<int> GetBatchSizeAsync()
+    {
+        return _settingsManager.GetValueAsync<int>(ModuleConstants.Settings.General.IndexPartitionSize);
     }
 }

--- a/src/VirtoCommerce.SearchModule.Data/Services/DummyIndexDocumentBuilder.cs
+++ b/src/VirtoCommerce.SearchModule.Data/Services/DummyIndexDocumentBuilder.cs
@@ -18,4 +18,9 @@ public class DummyIndexDocumentBuilder : IIndexSchemaBuilder, IIndexDocumentBuil
     {
         throw new NotImplementedException();
     }
+
+    public Task<IList<IndexDocument>> GetDocumentsAsync(IList<string> documentIds)
+    {
+        throw new NotImplementedException();
+    }
 }

--- a/src/VirtoCommerce.SearchModule.Data/Services/DummyIndexDocumentBuilder.cs
+++ b/src/VirtoCommerce.SearchModule.Data/Services/DummyIndexDocumentBuilder.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using VirtoCommerce.SearchModule.Core.Model;
 using VirtoCommerce.SearchModule.Core.Services;
@@ -13,7 +14,7 @@ public class DummyIndexDocumentBuilder : IIndexSchemaBuilder, IIndexDocumentBuil
         throw new NotImplementedException();
     }
 
-    public Task<IList<IndexDocument>> GetDocumentsAsync(IList<string> documentIds)
+    public Task<IList<IndexDocument>> GetDocumentsAsync(IList<string> documentIds, CancellationToken cancellationToken)
     {
         throw new NotImplementedException();
     }

--- a/src/VirtoCommerce.SearchModule.Data/Services/InMemoryIndexDocumentChangeFeed.cs
+++ b/src/VirtoCommerce.SearchModule.Data/Services/InMemoryIndexDocumentChangeFeed.cs
@@ -2,58 +2,65 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using VirtoCommerce.SearchModule.Core.Model;
 using VirtoCommerce.SearchModule.Core.Services;
 
-namespace VirtoCommerce.SearchModule.Data.Services
+namespace VirtoCommerce.SearchModule.Data.Services;
+
+/// <summary>
+/// Change feed for a specific set of documents.
+/// This allows us to build all indexation logic on top of a change feed.
+/// </summary>
+public class InMemoryIndexDocumentChangeFeed : IIndexDocumentChangeFeed
 {
-    /// <summary>
-    /// Change feed for a specific set of documents.
-    /// This allows us to build all indexation logic on top of a change feed.
-    /// </summary>
-    public class InMemoryIndexDocumentChangeFeed : IIndexDocumentChangeFeed
+    protected string[] DocumentIds { get; }
+    protected IndexDocumentChangeType ChangeType { get; }
+    protected long Skip { get; set; }
+    protected long Take { get; }
+
+    public long? TotalCount { get; }
+
+    public InMemoryIndexDocumentChangeFeed(string[] documentIds, IndexDocumentChangeType changeType, long take)
     {
-        protected string[] DocumentIds { get; }
-        protected IndexDocumentChangeType ChangeType { get; }
-        protected long Skip { get; set; }
-        protected long Take { get; }
+        DocumentIds = documentIds ?? throw new ArgumentNullException(nameof(documentIds));
+        ChangeType = changeType;
+        TotalCount = documentIds.Length;
+        Take = take;
+    }
 
-        public long? TotalCount { get; }
+    public Task<IReadOnlyCollection<IndexDocumentChange>> GetNextBatch()
+    {
+        return GetNextBatch(CancellationToken.None);
+    }
 
-        public InMemoryIndexDocumentChangeFeed(string[] documentIds, IndexDocumentChangeType changeType, long take)
+    public Task<IReadOnlyCollection<IndexDocumentChange>> GetNextBatch(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        IReadOnlyCollection<IndexDocumentChange> result = null;
+
+        if (Skip < TotalCount)
         {
-            DocumentIds = documentIds ?? throw new ArgumentNullException(nameof(documentIds));
-            ChangeType = changeType;
-            TotalCount = documentIds.Length;
-            Take = take;
-        }
-
-        public Task<IReadOnlyCollection<IndexDocumentChange>> GetNextBatch()
-        {
-            IReadOnlyCollection<IndexDocumentChange> result = null;
-
-            if (Skip < TotalCount)
-            {
-                var changes = DocumentIds
-                    .Skip((int)Skip)
-                    .Take((int)Take)
-                    .Select(x => new IndexDocumentChange
-                    {
-                        DocumentId = x,
-                        ChangeDate = DateTime.UtcNow,
-                        ChangeType = ChangeType
-                    })
-                    .ToList();
-
-                if (changes.Any())
+            var changes = DocumentIds
+                .Skip((int)Skip)
+                .Take((int)Take)
+                .Select(x => new IndexDocumentChange
                 {
-                    result = new ReadOnlyCollection<IndexDocumentChange>(changes);
-                    Skip += changes.Count;
-                }
-            }
+                    DocumentId = x,
+                    ChangeDate = DateTime.UtcNow,
+                    ChangeType = ChangeType
+                })
+                .ToList();
 
-            return Task.FromResult(result);
+            if (changes.Any())
+            {
+                result = new ReadOnlyCollection<IndexDocumentChange>(changes);
+                Skip += changes.Count;
+            }
         }
+
+        return Task.FromResult(result);
     }
 }

--- a/src/VirtoCommerce.SearchModule.Data/Services/IndexDocumentChangeFeedFactoryAdapter.cs
+++ b/src/VirtoCommerce.SearchModule.Data/Services/IndexDocumentChangeFeedFactoryAdapter.cs
@@ -2,75 +2,88 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using VirtoCommerce.SearchModule.Core.Model;
 using VirtoCommerce.SearchModule.Core.Services;
 
-namespace VirtoCommerce.SearchModule.Data.Services
+namespace VirtoCommerce.SearchModule.Data.Services;
+
+/// <summary>
+/// Implements IIndexDocumentChangeFeedFactory on top of the older IIndexDocumentChangesProvider
+/// to support backwards compatibility.
+/// </summary>
+public class IndexDocumentChangeFeedFactoryAdapter : IIndexDocumentChangeFeedFactory
 {
-    /// <summary>
-    /// Implements IIndexDocumentChangeFeedFactory on top of the older IIndexDocumentChangesProvider
-    /// to support backwards compatibility.
-    /// </summary>
-    public class IndexDocumentChangeFeedFactoryAdapter : IIndexDocumentChangeFeedFactory
+    private readonly IIndexDocumentChangesProvider _provider;
+
+    public IndexDocumentChangeFeedFactoryAdapter(IIndexDocumentChangesProvider provider)
     {
-        private readonly IIndexDocumentChangesProvider _provider;
+        _provider = provider ?? throw new ArgumentNullException(nameof(provider));
+    }
 
-        public IndexDocumentChangeFeedFactoryAdapter(IIndexDocumentChangesProvider provider)
+    public virtual Task<IIndexDocumentChangeFeed> CreateFeed(DateTime? startDate, DateTime? endDate, int batchSize)
+    {
+        return CreateFeed(startDate, endDate, batchSize, CancellationToken.None);
+    }
+
+    public virtual async Task<IIndexDocumentChangeFeed> CreateFeed(DateTime? startDate, DateTime? endDate, int batchSize, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var totalCount = await _provider.GetTotalChangesCountAsync(startDate, endDate, cancellationToken);
+        return new IndexDocumentChangeFeedForProvider(_provider, startDate, endDate, totalCount, batchSize);
+    }
+
+    protected class IndexDocumentChangeFeedForProvider : IIndexDocumentChangeFeed
+    {
+        protected IIndexDocumentChangesProvider Provider { get; }
+        protected DateTime? StartDate { get; }
+        protected DateTime? EndDate { get; }
+
+        public long? TotalCount { get; set; }
+        protected long Skip { get; set; }
+        protected long Take { get; }
+
+        public IndexDocumentChangeFeedForProvider(IIndexDocumentChangesProvider provider,
+            DateTime? startDate, DateTime? endDate, long totalCount, long take)
         {
-            _provider = provider ?? throw new ArgumentNullException(nameof(provider));
+            Provider = provider ?? throw new ArgumentNullException(nameof(provider));
+            StartDate = startDate;
+            EndDate = endDate;
+            TotalCount = totalCount;
+            Take = take;
         }
 
-        public virtual async Task<IIndexDocumentChangeFeed> CreateFeed(DateTime? startDate, DateTime? endDate, int batchSize)
+        public Task<IReadOnlyCollection<IndexDocumentChange>> GetNextBatch()
         {
-            var totalCount = await _provider.GetTotalChangesCountAsync(startDate, endDate);
-            return new IndexDocumentChangeFeedForProvider(_provider, startDate, endDate, totalCount, batchSize);
+            return GetNextBatch(CancellationToken.None);
         }
 
-        protected class IndexDocumentChangeFeedForProvider : IIndexDocumentChangeFeed
+        public async Task<IReadOnlyCollection<IndexDocumentChange>> GetNextBatch(CancellationToken cancellationToken)
         {
-            protected IIndexDocumentChangesProvider Provider { get; }
-            protected DateTime? StartDate { get; }
-            protected DateTime? EndDate { get; }
+            cancellationToken.ThrowIfCancellationRequested();
 
-            public long? TotalCount { get; set; }
-            protected long Skip { get; set; }
-            protected long Take { get; }
+            IReadOnlyCollection<IndexDocumentChange> result = null;
 
-            public IndexDocumentChangeFeedForProvider(IIndexDocumentChangesProvider provider,
-                DateTime? startDate, DateTime? endDate, long totalCount, long take)
+            if (Skip < TotalCount)
             {
-                Provider = provider ?? throw new ArgumentNullException(nameof(provider));
-                StartDate = startDate;
-                EndDate = endDate;
-                TotalCount = totalCount;
-                Take = take;
-            }
-
-            public async Task<IReadOnlyCollection<IndexDocumentChange>> GetNextBatch()
-            {
-                IReadOnlyCollection<IndexDocumentChange> result = null;
-
-                if (Skip < TotalCount)
+                var changes = await Provider.GetChangesAsync(StartDate, EndDate, Skip, Take, cancellationToken);
+                if (changes.Any())
                 {
-                    var changes = await Provider.GetChangesAsync(StartDate, EndDate, Skip, Take);
-                    if (changes.Any())
+                    if (StartDate != null && EndDate != null)
                     {
-                        if (StartDate != null && EndDate != null)
+                        foreach (var change in changes)
                         {
-                            foreach (var change in changes)
-                            {
-                                change.Provider = Provider;
-                            }
+                            change.Provider = Provider;
                         }
-
-                        result = new ReadOnlyCollection<IndexDocumentChange>(changes);
-                        Skip += changes.Count;
                     }
-                }
 
-                return result;
+                    result = new ReadOnlyCollection<IndexDocumentChange>(changes);
+                    Skip += changes.Count;
+                }
             }
+
+            return result;
         }
     }
 }

--- a/src/VirtoCommerce.SearchModule.Data/Services/IndexingManager.cs
+++ b/src/VirtoCommerce.SearchModule.Data/Services/IndexingManager.cs
@@ -130,7 +130,25 @@ public class IndexingManager : IIndexingManager
             return new IndexingResult();
         }
 
-        var partialUpdate = false;
+        var plan = BuildIndexDocumentsPlan(documentType, builderTypes, configuration);
+
+        var documents = await GetDocumentsAsync(documentType, documentIds, plan.PrimaryBuilder, plan.AdditionalBuilders, cancellationToken);
+
+        var result = plan.UsePartialUpdate && _searchProvider.Is<ISupportPartialUpdate>(documentType, out var supportPartialUpdateProvider)
+            ? await supportPartialUpdateProvider.IndexPartialAsync(documentType, documents)
+            : await _searchProvider.IndexAsync(documentType, documents);
+
+        return result;
+    }
+
+    /// <summary>
+    /// Picks the primary/secondary builders and decides whether the search provider should be
+    /// driven via partial-update for the given <paramref name="documentType"/>.
+    /// Extracted from <see cref="IndexDocumentsAsync(string, string[], IEnumerable{string}, CancellationToken)"/>
+    /// to keep its cyclomatic complexity manageable (Sonar S1541).
+    /// </summary>
+    protected virtual IndexDocumentsPlan BuildIndexDocumentsPlan(string documentType, IEnumerable<string> builderTypes, IndexDocumentConfiguration configuration)
+    {
         var builderTypesList = (builderTypes as IList<string> ?? builderTypes?.ToList()) ?? Array.Empty<string>();
         var primaryDocumentBuilder = configuration.DocumentSource.DocumentBuilder;
 
@@ -139,27 +157,35 @@ public class IndexingManager : IIndexingManager
             .Select(s => s.DocumentBuilder)
             .ToList() ?? new List<IIndexDocumentBuilder>();
 
-        if (builderTypesList.Any() && additionalDocumentBuilders.Any() && _searchProvider.Is<ISupportPartialUpdate>(documentType) && PartialDocumentUpdateEnabled)
-        {
-            partialUpdate = true;
-            additionalDocumentBuilders = additionalDocumentBuilders.Where(x => builderTypesList.Contains(x.GetType().FullName)).ToList();
+        var canPartialUpdate =
+            builderTypesList.Any() &&
+            additionalDocumentBuilders.Any() &&
+            _searchProvider.Is<ISupportPartialUpdate>(documentType) &&
+            PartialDocumentUpdateEnabled;
 
-            // In case of changing main object itself, there would be only primary document builder,
-            // but in the other cases, when changed additional dependent objects, primary builder should be set to null.
-            if (!builderTypesList.Contains(primaryDocumentBuilder.GetType().FullName))
-            {
-                primaryDocumentBuilder = null;
-            }
+        if (!canPartialUpdate)
+        {
+            return new IndexDocumentsPlan(false, primaryDocumentBuilder, additionalDocumentBuilders);
         }
 
-        var documents = await GetDocumentsAsync(documentType, documentIds, primaryDocumentBuilder, additionalDocumentBuilders, cancellationToken);
+        additionalDocumentBuilders = additionalDocumentBuilders
+            .Where(x => builderTypesList.Contains(x.GetType().FullName))
+            .ToList();
 
-        var result = partialUpdate && _searchProvider.Is<ISupportPartialUpdate>(documentType, out var supportPartialUpdateProvider)
-            ? await supportPartialUpdateProvider.IndexPartialAsync(documentType, documents)
-            : await _searchProvider.IndexAsync(documentType, documents);
+        // In case of changing main object itself, there would be only primary document builder,
+        // but in the other cases, when changed additional dependent objects, primary builder should be set to null.
+        if (!builderTypesList.Contains(primaryDocumentBuilder.GetType().FullName))
+        {
+            primaryDocumentBuilder = null;
+        }
 
-        return result;
+        return new IndexDocumentsPlan(true, primaryDocumentBuilder, additionalDocumentBuilders);
     }
+
+    protected readonly record struct IndexDocumentsPlan(
+        bool UsePartialUpdate,
+        IIndexDocumentBuilder PrimaryBuilder,
+        IList<IIndexDocumentBuilder> AdditionalBuilders);
 
     public virtual Task<IndexingResult> DeleteDocumentsAsync(string documentType, string[] documentIds)
     {
@@ -488,21 +514,10 @@ public class IndexingManager : IIndexingManager
             var tasks = secondaryDocumentBuilders.Select(p => p.GetDocumentsAsync(idChunk, cancellationToken));
             var chunkResults = await Task.WhenAll(tasks);
 
-            foreach (var chunkResult in chunkResults)
-            {
-                if (chunkResult == null)
-                {
-                    continue;
-                }
-
-                foreach (var document in chunkResult)
-                {
-                    if (document != null)
-                    {
-                        result.Add(document);
-                    }
-                }
-            }
+            var documents = chunkResults
+                .Where(c => c != null)
+                .SelectMany(c => c.Where(d => d != null));
+            result.AddRange(documents);
         }
 
         return result;
@@ -526,17 +541,9 @@ public class IndexingManager : IIndexingManager
             cancellationToken.ThrowIfCancellationRequested();
 
             var chunkResult = await builder.GetDocumentsAsync(idChunk, cancellationToken);
-            if (chunkResult == null)
+            if (chunkResult != null)
             {
-                continue;
-            }
-
-            foreach (var document in chunkResult)
-            {
-                if (document != null)
-                {
-                    result.Add(document);
-                }
+                result.AddRange(chunkResult.Where(d => d != null));
             }
         }
 

--- a/src/VirtoCommerce.SearchModule.Data/Services/IndexingManager.cs
+++ b/src/VirtoCommerce.SearchModule.Data/Services/IndexingManager.cs
@@ -479,7 +479,6 @@ public class IndexingManager : IIndexingManager
         var result = new List<IndexDocument>();
         var chunkSize = _settingsManager?.GetValue<int>(GeneralSettings.IndexPartitionSize) ?? DefaultBatchSize;
 
-
         foreach (var idChunk in PaginateIds(documentIds, chunkSize))
         {
             cancellationToken.ThrowIfCancellationRequested();

--- a/src/VirtoCommerce.SearchModule.Data/Services/IndexingManager.cs
+++ b/src/VirtoCommerce.SearchModule.Data/Services/IndexingManager.cs
@@ -292,6 +292,8 @@ public class IndexingManager : IIndexingManager
         BatchIndexingOptions batchOptions,
         CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         var result = new IndexingResult();
         var documentType = batchOptions.DocumentType;
 
@@ -304,6 +306,8 @@ public class IndexingManager : IIndexingManager
 
         foreach (var id in documentIds)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             var builders = changes
                 .Where(x => x.DocumentId == id)
                 .SelectMany(x => GetDocumentBuilders(documentType, x.Provider))
@@ -311,6 +315,9 @@ public class IndexingManager : IIndexingManager
                 .ToList();
 
             var documents = await GetDocumentsAsync(batchOptions.DocumentType, [id], null, builders, cancellationToken);
+
+            cancellationToken.ThrowIfCancellationRequested();
+
             var indexingResult = await supportPartialUpdateProvider.IndexPartialAsync(documentType, documents);
 
             result.Items.AddRange(indexingResult.Items);
@@ -344,6 +351,13 @@ public class IndexingManager : IIndexingManager
                 }
                 else
                 {
+                    // Re-check after the build: a builder using the legacy default-impl forwarder
+                    // may not observe the token, and even cancellation-aware builders can return
+                    // normally if the cancel signal arrives between completion and this point.
+                    // Without this check we would commit the in-flight batch after the user's
+                    // "Delete" took effect.
+                    cancellationToken.ThrowIfCancellationRequested();
+
                     result = batchOptions.Reindex &&
                              _searchProvider.Is<ISupportIndexSwap>(documentType, out var supportIndexSwapProvider)
                         ? await supportIndexSwapProvider.IndexWithBackupAsync(documentType, documents)

--- a/src/VirtoCommerce.SearchModule.Data/Services/IndexingManager.cs
+++ b/src/VirtoCommerce.SearchModule.Data/Services/IndexingManager.cs
@@ -6,710 +6,833 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Settings;
+using VirtoCommerce.SearchModule.Core;
 using VirtoCommerce.SearchModule.Core.Extensions;
 using VirtoCommerce.SearchModule.Core.Model;
 using VirtoCommerce.SearchModule.Core.Services;
 using GeneralSettings = VirtoCommerce.SearchModule.Core.ModuleConstants.Settings.General;
 
-namespace VirtoCommerce.SearchModule.Data.Services
+namespace VirtoCommerce.SearchModule.Data.Services;
+
+/// <summary>
+/// Implement the functionality of indexing
+/// </summary>
+public class IndexingManager : IIndexingManager
 {
+    public const int DefaultBatchSize = 50;
+
     /// <summary>
-    /// Implement the functionality of indexing
+    /// Number of sub-chunks each change-feed batch is split into before being passed to a document builder.
+    /// A value of N means the cancellation token is polled at least N times per batch, capping the worst-case
+    /// wait between pressing "Delete" in the Hangfire UI and the indexing job aborting at roughly 1/N of a batch.
     /// </summary>
-    public class IndexingManager : IIndexingManager
+    protected const int BuilderChunksPerBatch = 5;
+
+    /// <summary>
+    /// Sub-chunk size used inside <see cref="GetDocumentsAsync"/> when calling individual document builders.
+    /// Derived from the <c>VirtoCommerce.Search.IndexPartitionSize</c> setting so the operator has a single
+    /// knob: lowering the partition size shrinks both change-feed batches AND per-builder calls, improving
+    /// cancellation responsiveness at the cost of more round-trips. Computed as
+    /// <c>max(1, IndexPartitionSize / <see cref="BuilderChunksPerBatch"/>)</c>.
+    /// </summary>
+    protected virtual int BuilderChunkSize
     {
-        public const int DefaultBatchSize = 50;
-
-        private readonly ISearchProvider _searchProvider;
-        private readonly IEnumerable<IndexDocumentConfiguration> _configurations;
-        private readonly SearchOptions _searchOptions;
-        private readonly ISettingsManager _settingsManager;
-        private readonly IEnumerable<IIndexDocumentConverter> _documentConverters;
-
-        private bool PartialDocumentUpdateEnabled
+        get
         {
-            get
+            var partitionSize = _settingsManager?.GetValue<int>(GeneralSettings.IndexPartitionSize)
+                                ?? ModuleConstants.Settings.DefaultIndexPartitionSize;
+            if (partitionSize <= 0)
             {
-                return _settingsManager.GetValue<bool>(GeneralSettings.EnablePartialDocumentUpdate);
+                partitionSize = ModuleConstants.Settings.DefaultIndexPartitionSize;
+            }
+            return Math.Max(1, partitionSize / BuilderChunksPerBatch);
+        }
+    }
+
+    private readonly ISearchProvider _searchProvider;
+    private readonly IEnumerable<IndexDocumentConfiguration> _configurations;
+    private readonly SearchOptions _searchOptions;
+    private readonly ISettingsManager _settingsManager;
+    private readonly IEnumerable<IIndexDocumentConverter> _documentConverters;
+
+    private bool PartialDocumentUpdateEnabled
+    {
+        get
+        {
+            return _settingsManager.GetValue<bool>(GeneralSettings.EnablePartialDocumentUpdate);
+        }
+    }
+
+    public IndexingManager(
+        ISearchProvider searchProvider,
+        IEnumerable<IndexDocumentConfiguration> configurations,
+        IOptions<SearchOptions> searchOptions,
+        ISettingsManager settingsManager,
+        IEnumerable<IIndexDocumentConverter> documentConverters)
+    {
+        _searchProvider = searchProvider ?? throw new ArgumentNullException(nameof(searchProvider));
+        _configurations = configurations ?? throw new ArgumentNullException(nameof(configurations));
+        _searchOptions = searchOptions.Value;
+        _settingsManager = settingsManager;
+        _documentConverters = documentConverters;
+    }
+
+    public virtual async Task<IndexState> GetIndexStateAsync(string documentType)
+    {
+        var result = await GetIndexStateAsync(documentType, getBackupIndexState: false);
+
+        return result;
+    }
+
+    public virtual async Task<IEnumerable<IndexState>> GetIndicesStateAsync(string documentType)
+    {
+        var result = new List<IndexState> { await GetIndexStateAsync(documentType, getBackupIndexState: false) };
+
+        if (_searchProvider.Is<ISupportIndexSwap>(documentType))
+        {
+            result.Add(await GetIndexStateAsync(documentType, getBackupIndexState: true));
+        }
+
+        return result;
+    }
+
+    public virtual Task IndexAllDocumentsAsync(IndexingOptions options, Action<IndexingProgress> progressCallback, CancellationToken cancellationToken)
+    {
+        return IndexAsync(options, progressCallback, cancellationToken);
+    }
+
+    public virtual Task IndexChangesAsync(IndexingOptions options, Action<IndexingProgress> progressCallback, CancellationToken cancellationToken)
+    {
+        return IndexAsync(options, progressCallback, cancellationToken);
+    }
+
+    public virtual async Task IndexAsync(IndexingOptions options, Action<IndexingProgress> progressCallback, CancellationToken cancellationToken)
+    {
+        ValidateOptions(options);
+
+        if (GetConfiguration(options.DocumentType, out var configuration))
+        {
+            await ProcessConfigurationAsync(configuration, options, progressCallback, cancellationToken);
+        }
+    }
+
+    public virtual Task<IndexingResult> IndexDocumentsAsync(string documentType, string[] documentIds, IEnumerable<string> builderTypes = null)
+    {
+        return IndexDocumentsAsync(documentType, documentIds, builderTypes, CancellationToken.None);
+    }
+
+    public virtual async Task<IndexingResult> IndexDocumentsAsync(string documentType, string[] documentIds, IEnumerable<string> builderTypes, CancellationToken cancellationToken)
+    {
+        // TODO: Reuse general index API?
+
+        if (!GetConfiguration(documentType, out var configuration))
+        {
+            return new IndexingResult();
+        }
+
+        var partialUpdate = false;
+        var builderTypesList = (builderTypes as IList<string> ?? builderTypes?.ToList()) ?? Array.Empty<string>();
+        var primaryDocumentBuilder = configuration.DocumentSource.DocumentBuilder;
+
+        var additionalDocumentBuilders = configuration.RelatedSources
+            ?.Where(s => s.DocumentBuilder != null)
+            .Select(s => s.DocumentBuilder)
+            .ToList() ?? new List<IIndexDocumentBuilder>();
+
+        if (builderTypesList.Any() && additionalDocumentBuilders.Any() && _searchProvider.Is<ISupportPartialUpdate>(documentType) && PartialDocumentUpdateEnabled)
+        {
+            partialUpdate = true;
+            additionalDocumentBuilders = additionalDocumentBuilders.Where(x => builderTypesList.Contains(x.GetType().FullName)).ToList();
+
+            // In case of changing main object itself, there would be only primary document builder,
+            // but in the other cases, when changed additional dependent objects, primary builder should be set to null.
+            if (!builderTypesList.Contains(primaryDocumentBuilder.GetType().FullName))
+            {
+                primaryDocumentBuilder = null;
             }
         }
 
-        public IndexingManager(
-            ISearchProvider searchProvider,
-            IEnumerable<IndexDocumentConfiguration> configurations,
-            IOptions<SearchOptions> searchOptions,
-            ISettingsManager settingsManager,
-            IEnumerable<IIndexDocumentConverter> documentConverters)
+        var documents = await GetDocumentsAsync(documentType, documentIds, primaryDocumentBuilder, additionalDocumentBuilders, cancellationToken);
+
+        var result = partialUpdate && _searchProvider.Is<ISupportPartialUpdate>(documentType, out var supportPartialUpdateProvider)
+            ? await supportPartialUpdateProvider.IndexPartialAsync(documentType, documents)
+            : await _searchProvider.IndexAsync(documentType, documents);
+
+        return result;
+    }
+
+    public virtual Task<IndexingResult> DeleteDocumentsAsync(string documentType, string[] documentIds)
+    {
+        return DeleteDocumentsAsync(documentType, documentIds as IList<string>);
+    }
+
+    public virtual Task<IndexingResult> DeleteDocumentsAsync(string documentType, string[] documentIds, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return DeleteDocumentsAsync(documentType, documentIds as IList<string>);
+    }
+
+    public virtual async Task<IndexingResult> DeleteDocumentsAsync(string documentType, IList<string> documentIds)
+    {
+        var documents = documentIds.Select(id => new IndexDocument(id)).ToList();
+        return await _searchProvider.RemoveAsync(documentType, documents);
+    }
+
+    protected virtual async Task ProcessConfigurationAsync(
+        IndexDocumentConfiguration configuration,
+        IndexingOptions options,
+        Action<IndexingProgress> progressCallback,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        await PrepareIndexAsync(options, progressCallback, cancellationToken);
+
+        var documentType = options.DocumentType;
+        var processedCount = 0L;
+        long? totalCount = null;
+
+        void Progress(string message = null, IList<string> errors = null)
         {
-            _searchProvider = searchProvider ?? throw new ArgumentNullException(nameof(searchProvider));
-            _configurations = configurations ?? throw new ArgumentNullException(nameof(configurations));
-            _searchOptions = searchOptions.Value;
-            _settingsManager = settingsManager;
-            _documentConverters = documentConverters;
+            ReportProgress(progressCallback, documentType, message, processedCount, totalCount, errors);
         }
 
-        public virtual async Task<IndexState> GetIndexStateAsync(string documentType)
+        Progress("calculating total count");
+
+        var batchOptions = new BatchIndexingOptions
         {
-            var result = await GetIndexStateAsync(documentType, getBackupIndexState: false);
-
-            return result;
-        }
-
-        public virtual async Task<IEnumerable<IndexState>> GetIndicesStateAsync(string documentType)
-        {
-            var result = new List<IndexState> { await GetIndexStateAsync(documentType, getBackupIndexState: false) };
-
-            if (_searchProvider.Is<ISupportIndexSwap>(documentType))
-            {
-                result.Add(await GetIndexStateAsync(documentType, getBackupIndexState: true));
-            }
-
-            return result;
-        }
-
-        public virtual Task IndexAllDocumentsAsync(IndexingOptions options, Action<IndexingProgress> progressCallback, ICancellationToken cancellationToken)
-        {
-            return IndexAsync(options, progressCallback, cancellationToken);
-        }
-
-        public virtual Task IndexChangesAsync(IndexingOptions options, Action<IndexingProgress> progressCallback, ICancellationToken cancellationToken)
-        {
-            return IndexAsync(options, progressCallback, cancellationToken);
-        }
-
-        public virtual async Task IndexAsync(IndexingOptions options, Action<IndexingProgress> progressCallback, ICancellationToken cancellationToken)
-        {
-            ValidateOptions(options);
-
-            if (GetConfiguration(options.DocumentType, out var configuration))
-            {
-                await ProcessConfigurationAsync(configuration, options, progressCallback, cancellationToken);
-            }
-        }
-
-        public virtual async Task<IndexingResult> IndexDocumentsAsync(string documentType, string[] documentIds, IEnumerable<string> builderTypes = null)
-        {
-            // TODO: Reuse general index API?
-
-            if (!GetConfiguration(documentType, out var configuration))
-            {
-                return new IndexingResult();
-            }
-
-            var partialUpdate = false;
-            var builderTypesList = (builderTypes as IList<string> ?? builderTypes?.ToList()) ?? Array.Empty<string>();
-            var primaryDocumentBuilder = configuration.DocumentSource.DocumentBuilder;
-
-            var additionalDocumentBuilders = configuration.RelatedSources
+            DocumentType = documentType,
+            Reindex = options.DeleteExistingIndex,
+            PrimaryDocumentBuilder = configuration.DocumentSource.DocumentBuilder,
+            SecondaryDocumentBuilders = configuration.RelatedSources
                 ?.Where(s => s.DocumentBuilder != null)
                 .Select(s => s.DocumentBuilder)
-                .ToList() ?? new List<IIndexDocumentBuilder>();
+                .ToList(),
+        };
 
-            if (builderTypesList.Any() && additionalDocumentBuilders.Any() && _searchProvider.Is<ISupportPartialUpdate>(documentType) && PartialDocumentUpdateEnabled)
+        var feeds = await GetChangeFeedsAsync(configuration, options, cancellationToken);
+
+        // Try to get total count to indicate progress. Some feeds don't have a total count.
+        totalCount = feeds.Any(x => x.TotalCount == null)
+            ? null
+            : feeds.Sum(x => x.TotalCount ?? 0);
+
+        var changes = await GetNextChangesAsync(feeds, cancellationToken);
+        while (changes.Any())
+        {
+            var indexingResult = await ProcessChangesAsync(changes, batchOptions, cancellationToken);
+
+            processedCount += changes.Count;
+            Progress(errors: GetIndexingErrors(indexingResult));
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            changes = await GetNextChangesAsync(feeds, cancellationToken);
+        }
+
+        // indexation complete, swap indexes back
+        await SwapIndicesAsync(options);
+
+        totalCount ??= processedCount;
+        Progress("indexation finished");
+    }
+
+    protected virtual async Task<IList<IndexDocumentChange>> GetNextChangesAsync(IList<IIndexDocumentChangeFeed> feeds, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var batches = await Task.WhenAll(feeds.Select(f => f.GetNextBatch(cancellationToken)));
+
+        var changes = batches
+            .Where(b => b != null)
+            .SelectMany(b => b)
+            .ToList();
+
+        return changes;
+    }
+
+    protected virtual async Task<IndexingResult> ProcessChangesAsync(
+        IList<IndexDocumentChange> changes,
+        BatchIndexingOptions batchOptions,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var result = new IndexingResult();
+        var documentType = batchOptions.DocumentType;
+
+        // Full changes don't have changes provider specified because we don't set it for manual indexation.
+        var fullChanges = _searchProvider.Is<ISupportPartialUpdate>(documentType) && PartialDocumentUpdateEnabled
+            ? changes
+                .Where(x =>
+                    x.ChangeType is IndexDocumentChangeType.Deleted or IndexDocumentChangeType.Created ||
+                    GetDocumentBuilders(documentType, x.Provider).IsNullOrEmpty())
+                .ToList()
+            : changes;
+
+        var partialChanges = changes.Except(fullChanges).ToList();
+        var partialResult = await ProcessPartialDocumentsAsync(partialChanges, batchOptions, cancellationToken);
+
+        var groups = GetLatestChangesForEachDocumentGroupedByChangeType(fullChanges);
+
+        foreach (var (changeType, documentIds) in groups)
+        {
+            var groupResult = await ProcessDocumentsAsync(changeType, documentIds, batchOptions, cancellationToken);
+
+            if (groupResult?.Items != null)
             {
-                partialUpdate = true;
-                additionalDocumentBuilders = additionalDocumentBuilders.Where(x => builderTypesList.Contains(x.GetType().FullName)).ToList();
-
-                // In case of changing main object itself, there would be only primary document builder,
-                // but in the other cases, when changed additional dependent objects, primary builder should be set to null.
-                if (!builderTypesList.Contains(primaryDocumentBuilder.GetType().FullName))
-                {
-                    primaryDocumentBuilder = null;
-                }
+                result.Items.AddRange(groupResult.Items);
             }
+        }
 
-            var cancellationToken = new CancellationTokenWrapper(CancellationToken.None);
-            var documents = await GetDocumentsAsync(documentType, documentIds, primaryDocumentBuilder, additionalDocumentBuilders, cancellationToken);
+        result.Items.AddRange(partialResult.Items);
 
-            var result = partialUpdate && _searchProvider.Is<ISupportPartialUpdate>(documentType, out var supportPartialUpdateProvider)
-                ? await supportPartialUpdateProvider.IndexPartialAsync(documentType, documents)
-                : await _searchProvider.IndexAsync(documentType, documents);
+        return result;
+    }
 
+    protected virtual async Task<IndexingResult> ProcessPartialDocumentsAsync(
+        IList<IndexDocumentChange> changes,
+        BatchIndexingOptions batchOptions,
+        CancellationToken cancellationToken)
+    {
+        var result = new IndexingResult();
+        var documentType = batchOptions.DocumentType;
+
+        if (!PartialDocumentUpdateEnabled || !_searchProvider.Is<ISupportPartialUpdate>(documentType, out var supportPartialUpdateProvider))
+        {
             return result;
         }
 
-        public virtual Task<IndexingResult> DeleteDocumentsAsync(string documentType, string[] documentIds)
+        var documentIds = changes.Select(x => x.DocumentId).Distinct();
+
+        foreach (var id in documentIds)
         {
-            return DeleteDocumentsAsync(documentType, documentIds as IList<string>);
-        }
-
-        public virtual async Task<IndexingResult> DeleteDocumentsAsync(string documentType, IList<string> documentIds)
-        {
-            var documents = documentIds.Select(id => new IndexDocument(id)).ToList();
-            return await _searchProvider.RemoveAsync(documentType, documents);
-        }
-
-        protected virtual async Task ProcessConfigurationAsync(
-            IndexDocumentConfiguration configuration,
-            IndexingOptions options,
-            Action<IndexingProgress> progressCallback,
-            ICancellationToken cancellationToken)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            await PrepareIndexAsync(options, progressCallback, cancellationToken);
-
-            var documentType = options.DocumentType;
-            var processedCount = 0L;
-            long? totalCount = null;
-
-            void Progress(string message = null, IList<string> errors = null)
-            {
-                ReportProgress(progressCallback, documentType, message, processedCount, totalCount, errors);
-            }
-
-            Progress("calculating total count");
-
-            var batchOptions = new BatchIndexingOptions
-            {
-                DocumentType = documentType,
-                Reindex = options.DeleteExistingIndex,
-                PrimaryDocumentBuilder = configuration.DocumentSource.DocumentBuilder,
-                SecondaryDocumentBuilders = configuration.RelatedSources
-                    ?.Where(s => s.DocumentBuilder != null)
-                    .Select(s => s.DocumentBuilder)
-                    .ToList(),
-            };
-
-            var feeds = await GetChangeFeedsAsync(configuration, options);
-
-            // Try to get total count to indicate progress. Some feeds don't have a total count.
-            totalCount = feeds.Any(x => x.TotalCount == null)
-                ? null
-                : feeds.Sum(x => x.TotalCount ?? 0);
-
-            var changes = await GetNextChangesAsync(feeds);
-            while (changes.Any())
-            {
-                var indexingResult = await ProcessChangesAsync(changes, batchOptions, cancellationToken);
-
-                processedCount += changes.Count;
-                Progress(errors: GetIndexingErrors(indexingResult));
-
-                cancellationToken.ThrowIfCancellationRequested();
-
-                changes = await GetNextChangesAsync(feeds);
-            }
-
-            // indexation complete, swap indexes back
-            await SwapIndicesAsync(options);
-
-            totalCount ??= processedCount;
-            Progress("indexation finished");
-        }
-
-        protected virtual async Task<IList<IndexDocumentChange>> GetNextChangesAsync(IList<IIndexDocumentChangeFeed> feeds)
-        {
-            var batches = await Task.WhenAll(feeds.Select(f => f.GetNextBatch()));
-
-            var changes = batches
-                .Where(b => b != null)
-                .SelectMany(b => b)
+            var builders = changes
+                .Where(x => x.DocumentId == id)
+                .SelectMany(x => GetDocumentBuilders(documentType, x.Provider))
+                .Distinct()
                 .ToList();
 
-            return changes;
+            var documents = await GetDocumentsAsync(batchOptions.DocumentType, [id], null, builders, cancellationToken);
+            var indexingResult = await supportPartialUpdateProvider.IndexPartialAsync(documentType, documents);
+
+            result.Items.AddRange(indexingResult.Items);
         }
 
-        protected virtual async Task<IndexingResult> ProcessChangesAsync(
-            IList<IndexDocumentChange> changes,
-            BatchIndexingOptions batchOptions,
-            ICancellationToken cancellationToken)
+        return result;
+    }
+
+    protected virtual async Task<IndexingResult> ProcessDocumentsAsync(
+        IndexDocumentChangeType changeType,
+        IList<string> documentIds,
+        BatchIndexingOptions batchOptions,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        IndexingResult result;
+        var documentType = batchOptions.DocumentType;
+
+        switch (changeType)
         {
-            cancellationToken.ThrowIfCancellationRequested();
+            case IndexDocumentChangeType.Deleted:
+                result = await DeleteDocumentsAsync(documentType, documentIds);
+                break;
+            case IndexDocumentChangeType.Modified or IndexDocumentChangeType.Created:
+                var documents = await GetDocumentsAsync(batchOptions.DocumentType, documentIds, batchOptions.PrimaryDocumentBuilder, batchOptions.SecondaryDocumentBuilders, cancellationToken);
 
-            var result = new IndexingResult();
-            var documentType = batchOptions.DocumentType;
-
-            // Full changes don't have changes provider specified because we don't set it for manual indexation.
-            var fullChanges = _searchProvider.Is<ISupportPartialUpdate>(documentType) && PartialDocumentUpdateEnabled
-                ? changes
-                    .Where(x =>
-                        x.ChangeType is IndexDocumentChangeType.Deleted or IndexDocumentChangeType.Created ||
-                        GetDocumentBuilders(documentType, x.Provider).IsNullOrEmpty())
-                    .ToList()
-                : changes;
-
-            var partialChanges = changes.Except(fullChanges).ToList();
-            var partialResult = await ProcessPartialDocumentsAsync(partialChanges, batchOptions, cancellationToken);
-
-            var groups = GetLatestChangesForEachDocumentGroupedByChangeType(fullChanges);
-
-            foreach (var (changeType, documentIds) in groups)
-            {
-                var groupResult = await ProcessDocumentsAsync(changeType, documentIds, batchOptions, cancellationToken);
-
-                if (groupResult?.Items != null)
+                if (documents.IsNullOrEmpty())
                 {
-                    result.Items.AddRange(groupResult.Items);
-                }
-            }
-
-            result.Items.AddRange(partialResult.Items);
-
-            return result;
-        }
-
-        protected virtual async Task<IndexingResult> ProcessPartialDocumentsAsync(
-            IList<IndexDocumentChange> changes,
-            BatchIndexingOptions batchOptions,
-            ICancellationToken cancellationToken)
-        {
-            var result = new IndexingResult();
-            var documentType = batchOptions.DocumentType;
-
-            if (!PartialDocumentUpdateEnabled || !_searchProvider.Is<ISupportPartialUpdate>(documentType, out var supportPartialUpdateProvider))
-            {
-                return result;
-            }
-
-            var documentIds = changes.Select(x => x.DocumentId).Distinct();
-
-            foreach (var id in documentIds)
-            {
-                var builders = changes
-                    .Where(x => x.DocumentId == id)
-                    .SelectMany(x => GetDocumentBuilders(documentType, x.Provider))
-                    .Distinct()
-                    .ToList();
-
-                var documents = await GetDocumentsAsync(batchOptions.DocumentType, [id], null, builders, cancellationToken);
-                var indexingResult = await supportPartialUpdateProvider.IndexPartialAsync(documentType, documents);
-
-                result.Items.AddRange(indexingResult.Items);
-            }
-
-            return result;
-        }
-
-        protected virtual async Task<IndexingResult> ProcessDocumentsAsync(
-            IndexDocumentChangeType changeType,
-            IList<string> documentIds,
-            BatchIndexingOptions batchOptions,
-            ICancellationToken cancellationToken)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            IndexingResult result;
-            var documentType = batchOptions.DocumentType;
-
-            switch (changeType)
-            {
-                case IndexDocumentChangeType.Deleted:
-                    result = await DeleteDocumentsAsync(documentType, documentIds);
-                    break;
-                case IndexDocumentChangeType.Modified or IndexDocumentChangeType.Created:
-                    var documents = await GetDocumentsAsync(batchOptions.DocumentType, documentIds, batchOptions.PrimaryDocumentBuilder, batchOptions.SecondaryDocumentBuilders, cancellationToken);
-
-                    if (documents.IsNullOrEmpty())
-                    {
-                        result = new IndexingResult();
-                    }
-                    else
-                    {
-                        result = batchOptions.Reindex &&
-                                 _searchProvider.Is<ISupportIndexSwap>(documentType, out var supportIndexSwapProvider)
-                            ? await supportIndexSwapProvider.IndexWithBackupAsync(documentType, documents)
-                            : await _searchProvider.IndexAsync(documentType, documents);
-                    }
-
-                    break;
-                default:
                     result = new IndexingResult();
-                    break;
-            }
-
-            return result;
-        }
-
-        protected virtual async Task<IList<IIndexDocumentChangeFeed>> GetChangeFeedsAsync(IndexDocumentConfiguration configuration, IndexingOptions options)
-        {
-            // Return in-memory change feed for specific set of document IDs.
-            if (options.DocumentIds != null)
-            {
-                return
-                [
-                    new InMemoryIndexDocumentChangeFeed(options.DocumentIds.ToArray(), IndexDocumentChangeType.Modified, options.BatchSize ?? DefaultBatchSize),
-                ];
-            }
-
-            var factories = new List<IIndexDocumentChangeFeedFactory>
-            {
-                GetChangeFeedFactory(configuration.DocumentSource)
-            };
-
-            // In case of 'full' re-index we don't want to include the related sources,
-            // because that would double the indexation work.
-            // E.g. All products would get indexed for the primary document source
-            // and then all products would get re-indexed for all the prices as well.
-            if (configuration.RelatedSources != null && (options.StartDate != null || options.EndDate != null))
-            {
-                factories.AddRange(configuration.RelatedSources.Select(GetChangeFeedFactory));
-            }
-
-            return await Task.WhenAll(factories.Select(x => x.CreateFeed(options.StartDate, options.EndDate, options.BatchSize ?? DefaultBatchSize)));
-        }
-
-        protected virtual IIndexDocumentChangeFeedFactory GetChangeFeedFactory(IndexDocumentSource documentSource)
-        {
-            documentSource.ChangeFeedFactory ??= new IndexDocumentChangeFeedFactoryAdapter(documentSource.ChangesProvider);
-
-            return documentSource.ChangeFeedFactory;
-        }
-
-        protected virtual IList<string> GetIndexingErrors(IndexingResult indexingResult)
-        {
-            var errors = indexingResult?.Items
-                ?.Where(i => !i.Succeeded)
-                .Select(i => $"{FormatId(i.Id)}, Error: {i.ErrorMessage}")
-                .ToArray();
-
-            return errors ?? [];
-        }
-
-        protected virtual string FormatId(string id)
-        {
-            return id?.Contains(':') == true
-                ? id
-                : $"ID: {id}";
-        }
-
-        protected virtual IDictionary<IndexDocumentChangeType, string[]> GetLatestChangesForEachDocumentGroupedByChangeType(IList<IndexDocumentChange> changes)
-        {
-            var result = changes
-                .GroupBy(c => c.DocumentId)
-                .Select(g => g.OrderByDescending(o => o.ChangeDate).First())
-                .GroupBy(c => c.ChangeType)
-                .ToDictionary(g => g.Key, g => g.Select(c => c.DocumentId).ToArray());
-
-            return result;
-        }
-
-        protected virtual async Task<IList<IndexDocument>> GetDocumentsAsync(
-            string documentType,
-            IList<string> documentIds,
-            IIndexDocumentBuilder primaryDocumentBuilder,
-            IList<IIndexDocumentBuilder> secondaryDocumentBuilders,
-            ICancellationToken cancellationToken)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            var primaryDocuments = primaryDocumentBuilder != null
-                ? (await primaryDocumentBuilder.GetDocumentsAsync(documentIds))?.Where(x => x != null).ToList()
-                : documentIds.Select(x => new IndexDocument(x)).ToList();
-
-            if (primaryDocuments?.Count > 0)
-            {
-                if (secondaryDocumentBuilders != null)
-                {
-                    var primaryDocumentIds = primaryDocuments.Select(d => d.Id).ToArray();
-                    var secondaryDocuments = await GetSecondaryDocumentsAsync(secondaryDocumentBuilders, primaryDocumentIds, cancellationToken);
-
-                    MergeDocuments(primaryDocuments, secondaryDocuments);
-                }
-
-                foreach (var document in primaryDocuments)
-                {
-                    AddSystemFields(document);
-                }
-
-                foreach (var converter in _documentConverters)
-                {
-                    await converter.ConvertAsync(documentType, primaryDocuments);
-                }
-
-                AggregateDocuments(primaryDocuments, primaryDocumentBuilder, secondaryDocumentBuilders);
-            }
-
-            return primaryDocuments;
-        }
-
-        protected virtual async Task<IList<IndexDocument>> GetSecondaryDocumentsAsync(
-            IList<IIndexDocumentBuilder> secondaryDocumentBuilders,
-            IList<string> documentIds,
-            ICancellationToken cancellationToken)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            var tasks = secondaryDocumentBuilders.Select(p => p.GetDocumentsAsync(documentIds));
-            var results = await Task.WhenAll(tasks);
-
-            var result = results
-                .Where(r => r != null)
-                .SelectMany(r => r.Where(d => d != null))
-                .ToList();
-
-            return result;
-        }
-
-        protected virtual void MergeDocuments(IList<IndexDocument> primaryDocuments, IList<IndexDocument> secondaryDocuments)
-        {
-            if (primaryDocuments.IsNullOrEmpty() || secondaryDocuments.IsNullOrEmpty())
-            {
-                return;
-            }
-
-            var secondaryDocumentGroups = secondaryDocuments
-                .GroupBy(d => d.Id)
-                .ToDictionary(g => g.Key, g => g, StringComparer.OrdinalIgnoreCase);
-
-            foreach (var primaryDocument in primaryDocuments)
-            {
-                if (secondaryDocumentGroups.TryGetValue(primaryDocument.Id, out var secondaryDocumentGroup))
-                {
-                    foreach (var secondaryDocument in secondaryDocumentGroup)
-                    {
-                        primaryDocument.Merge(secondaryDocument);
-                    }
-                }
-            }
-        }
-
-        protected void AggregateDocuments(IList<IndexDocument> documents, IIndexDocumentBuilder primaryDocumentBuilder, IList<IIndexDocumentBuilder> secondaryDocumentBuilders)
-        {
-            var aggregationKeyProvider = GetAggregationKeyProvider(primaryDocumentBuilder, secondaryDocumentBuilders);
-
-            if (aggregationKeyProvider == null)
-            {
-                return;
-            }
-
-            var aggregators = GetDocumentAggregators(primaryDocumentBuilder, secondaryDocumentBuilders);
-
-            if (aggregators.IsNullOrEmpty())
-            {
-                return;
-            }
-
-            var aggregationGroups = aggregationKeyProvider.GetGroups(documents);
-
-            foreach (var aggregator in aggregators)
-            {
-                foreach (var aggregationGroup in aggregationGroups)
-                {
-                    aggregator.Aggregate(aggregationGroup);
-                }
-            }
-        }
-
-        protected virtual IIndexDocumentAggregationGroupProvider GetAggregationKeyProvider(IIndexDocumentBuilder primaryDocumentBuilder, IList<IIndexDocumentBuilder> secondaryDocumentBuilders)
-        {
-            if (primaryDocumentBuilder is IIndexDocumentAggregationGroupProvider aggregationKeyProvider)
-            {
-                return aggregationKeyProvider;
-            }
-
-            if (secondaryDocumentBuilders != null)
-            {
-                return secondaryDocumentBuilders.OfType<IIndexDocumentAggregationGroupProvider>().FirstOrDefault();
-            }
-
-            return null;
-        }
-
-        protected virtual IList<IIndexDocumentAggregator> GetDocumentAggregators(IIndexDocumentBuilder primaryDocumentBuilder, IList<IIndexDocumentBuilder> secondaryDocumentBuilders)
-        {
-            var result = new List<IIndexDocumentAggregator>();
-
-            if (primaryDocumentBuilder is IIndexDocumentAggregator primaryDocumentAggregator)
-            {
-                result.Add(primaryDocumentAggregator);
-            }
-
-            if (secondaryDocumentBuilders != null)
-            {
-                result.AddRange(secondaryDocumentBuilders.OfType<IIndexDocumentAggregator>());
-            }
-
-            return result;
-        }
-
-        /// <summary>
-        /// Swap between active and backup indices, if supported
-        /// </summary>
-        protected virtual async Task SwapIndicesAsync(IndexingOptions options)
-        {
-            var documentType = options.DocumentType;
-
-            if (options.DeleteExistingIndex && _searchProvider.Is<ISupportIndexSwap>(documentType, out var swappingSupportedSearchProvider))
-            {
-                await swappingSupportedSearchProvider.SwapIndexAsync(documentType);
-            }
-        }
-
-        private async Task<IndexState> GetIndexStateAsync(string documentType, bool getBackupIndexState)
-        {
-            var result = new IndexState
-            {
-                DocumentType = documentType,
-                Provider = _searchProvider.GetProviderName(documentType, _searchOptions.Provider),
-                Scope = _searchOptions.GetScope(documentType),
-                IsActive = !getBackupIndexState,
-            };
-
-            var searchRequest = new SearchRequest
-            {
-                UseBackupIndex = getBackupIndexState,
-                Sorting = [new SortingField { FieldName = KnownDocumentFields.IndexationDate, IsDescending = true }],
-                Take = 1,
-            };
-
-            try
-            {
-                var searchResponse = await _searchProvider.SearchAsync(documentType, searchRequest);
-
-                result.IndexedDocumentsCount = searchResponse.TotalCount;
-                if (searchResponse.Documents?.Any() == true)
-                {
-                    var indexationDate = searchResponse.Documents[0].FirstOrDefault(kvp => kvp.Key.EqualsIgnoreCase(KnownDocumentFields.IndexationDate));
-                    if (DateTimeOffset.TryParse(indexationDate.Value.ToString(), out var lastIndexationDateTime))
-                    {
-                        result.LastIndexationDate = lastIndexationDateTime.DateTime;
-                    }
-                }
-            }
-            catch
-            {
-                // ignored
-            }
-
-            return result;
-        }
-
-        protected virtual async Task PrepareIndexAsync(IndexingOptions options, Action<IndexingProgress> progressCallback, ICancellationToken cancellationToken)
-        {
-            if (options.DeleteExistingIndex)
-            {
-                await DeleteIndexAsync(options, progressCallback, cancellationToken);
-                await CreateIndexAsync(options, progressCallback, cancellationToken);
-            }
-        }
-
-        protected virtual async Task DeleteIndexAsync(IndexingOptions options, Action<IndexingProgress> progressCallback, ICancellationToken cancellationToken)
-        {
-            var documentType = options.DocumentType;
-            ReportProgress(progressCallback, documentType, "deleting index");
-
-            await _searchProvider.DeleteIndexAsync(documentType);
-            // TODO: Wait until index is deleted
-        }
-
-        protected virtual async Task CreateIndexAsync(IndexingOptions options, Action<IndexingProgress> progressCallback, ICancellationToken cancellationToken)
-        {
-            var documentType = options.DocumentType;
-            ReportProgress(progressCallback, documentType, "creating index");
-
-            var schema = await BuildSchemaAsync(documentType);
-
-            if (_searchProvider.Is<ISupportIndexCreate>(documentType, out var supportIndexCreate))
-            {
-                await supportIndexCreate.CreateIndexAsync(documentType, schema);
-            }
-            else
-            {
-                var documents = new[] { schema };
-
-                if (_searchProvider.Is<ISupportIndexSwap>(documentType, out var supportIndexSwapProvider))
-                {
-                    await supportIndexSwapProvider.IndexWithBackupAsync(documentType, documents);
                 }
                 else
                 {
-                    await _searchProvider.IndexAsync(documentType, documents);
+                    result = batchOptions.Reindex &&
+                             _searchProvider.Is<ISupportIndexSwap>(documentType, out var supportIndexSwapProvider)
+                        ? await supportIndexSwapProvider.IndexWithBackupAsync(documentType, documents)
+                        : await _searchProvider.IndexAsync(documentType, documents);
                 }
 
-                await _searchProvider.RemoveAsync(documentType, documents);
+                break;
+            default:
+                result = new IndexingResult();
+                break;
+        }
+
+        return result;
+    }
+
+    protected virtual async Task<IList<IIndexDocumentChangeFeed>> GetChangeFeedsAsync(IndexDocumentConfiguration configuration, IndexingOptions options, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // Return in-memory change feed for specific set of document IDs.
+        if (options.DocumentIds != null)
+        {
+            return
+            [
+                new InMemoryIndexDocumentChangeFeed(options.DocumentIds.ToArray(), IndexDocumentChangeType.Modified, options.BatchSize ?? DefaultBatchSize),
+            ];
+        }
+
+        var factories = new List<IIndexDocumentChangeFeedFactory>
+        {
+            GetChangeFeedFactory(configuration.DocumentSource)
+        };
+
+        // In case of 'full' re-index we don't want to include the related sources,
+        // because that would double the indexation work.
+        // E.g. All products would get indexed for the primary document source
+        // and then all products would get re-indexed for all the prices as well.
+        if (configuration.RelatedSources != null && (options.StartDate != null || options.EndDate != null))
+        {
+            factories.AddRange(configuration.RelatedSources.Select(GetChangeFeedFactory));
+        }
+
+        return await Task.WhenAll(factories.Select(x => x.CreateFeed(options.StartDate, options.EndDate, options.BatchSize ?? DefaultBatchSize, cancellationToken)));
+    }
+
+    protected virtual IIndexDocumentChangeFeedFactory GetChangeFeedFactory(IndexDocumentSource documentSource)
+    {
+        documentSource.ChangeFeedFactory ??= new IndexDocumentChangeFeedFactoryAdapter(documentSource.ChangesProvider);
+
+        return documentSource.ChangeFeedFactory;
+    }
+
+    protected virtual IList<string> GetIndexingErrors(IndexingResult indexingResult)
+    {
+        var errors = indexingResult?.Items
+            ?.Where(i => !i.Succeeded)
+            .Select(i => $"{FormatId(i.Id)}, Error: {i.ErrorMessage}")
+            .ToArray();
+
+        return errors ?? [];
+    }
+
+    protected virtual string FormatId(string id)
+    {
+        return id?.Contains(':') == true
+            ? id
+            : $"ID: {id}";
+    }
+
+    protected virtual IDictionary<IndexDocumentChangeType, string[]> GetLatestChangesForEachDocumentGroupedByChangeType(IList<IndexDocumentChange> changes)
+    {
+        var result = changes
+            .GroupBy(c => c.DocumentId)
+            .Select(g => g.OrderByDescending(o => o.ChangeDate).First())
+            .GroupBy(c => c.ChangeType)
+            .ToDictionary(g => g.Key, g => g.Select(c => c.DocumentId).ToArray());
+
+        return result;
+    }
+
+    protected virtual async Task<IList<IndexDocument>> GetDocumentsAsync(
+        string documentType,
+        IList<string> documentIds,
+        IIndexDocumentBuilder primaryDocumentBuilder,
+        IList<IIndexDocumentBuilder> secondaryDocumentBuilders,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        IList<IndexDocument> primaryDocuments;
+        if (primaryDocumentBuilder != null)
+        {
+            primaryDocuments = await BuildDocumentsInChunksAsync(primaryDocumentBuilder, documentIds, cancellationToken);
+        }
+        else
+        {
+            primaryDocuments = documentIds.Select(x => new IndexDocument(x)).ToList();
+        }
+
+        if (primaryDocuments?.Count > 0)
+        {
+            if (secondaryDocumentBuilders != null)
+            {
+                var primaryDocumentIds = primaryDocuments.Select(d => d.Id).ToArray();
+                var secondaryDocuments = await GetSecondaryDocumentsAsync(secondaryDocumentBuilders, primaryDocumentIds, cancellationToken);
+
+                MergeDocuments(primaryDocuments, secondaryDocuments);
+            }
+
+            foreach (var document in primaryDocuments)
+            {
+                AddSystemFields(document);
+            }
+
+            foreach (var converter in _documentConverters)
+            {
+                await converter.ConvertAsync(documentType, primaryDocuments);
+            }
+
+            AggregateDocuments(primaryDocuments, primaryDocumentBuilder, secondaryDocumentBuilders);
+        }
+
+        return primaryDocuments;
+    }
+
+    protected virtual async Task<IList<IndexDocument>> GetSecondaryDocumentsAsync(
+        IList<IIndexDocumentBuilder> secondaryDocumentBuilders,
+        IList<string> documentIds,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var result = new List<IndexDocument>();
+
+        foreach (var idChunk in PaginateIds(documentIds))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var tasks = secondaryDocumentBuilders.Select(p => p.GetDocumentsAsync(idChunk, cancellationToken));
+            var chunkResults = await Task.WhenAll(tasks);
+
+            foreach (var chunkResult in chunkResults)
+            {
+                if (chunkResult == null)
+                {
+                    continue;
+                }
+
+                foreach (var document in chunkResult)
+                {
+                    if (document != null)
+                    {
+                        result.Add(document);
+                    }
+                }
             }
         }
 
-        protected virtual async Task<IndexDocument> BuildSchemaAsync(string documentType)
+        return result;
+    }
+
+    /// <summary>
+    /// Calls <paramref name="builder"/> in fixed-size sub-chunks (see <see cref="BuilderChunkSize"/>)
+    /// and polls <paramref name="cancellationToken"/> between chunks so the indexing job aborts
+    /// promptly when its Hangfire entry is deleted, even if individual builder calls are heavy
+    /// (e.g. paginated variation fetches).
+    /// </summary>
+    protected virtual async Task<IList<IndexDocument>> BuildDocumentsInChunksAsync(
+        IIndexDocumentBuilder builder,
+        IList<string> documentIds,
+        CancellationToken cancellationToken)
+    {
+        var result = new List<IndexDocument>();
+
+        foreach (var idChunk in PaginateIds(documentIds))
         {
-            var temporaryDocumentId = Guid.NewGuid().ToString("N");
-            var schema = new IndexDocument(temporaryDocumentId);
+            cancellationToken.ThrowIfCancellationRequested();
 
-            AddSystemFields(schema);
-
-            foreach (var schemaBuilder in GetSchemaBuilders(documentType))
+            var chunkResult = await builder.GetDocumentsAsync(idChunk, cancellationToken);
+            if (chunkResult == null)
             {
-                await schemaBuilder.BuildSchemaAsync(schema);
+                continue;
             }
 
-            return schema;
-        }
-
-        protected virtual void AddSystemFields(IndexDocument document)
-        {
-            document.AddFilterableDateTime(KnownDocumentFields.IndexationDate, DateTime.UtcNow);
-        }
-
-        protected virtual IEnumerable<IIndexSchemaBuilder> GetSchemaBuilders(string documentType)
-        {
-            return _configurations.GetDocumentSources(documentType)
-                .Select(x => x.DocumentBuilder)
-                .OfType<IIndexSchemaBuilder>();
-        }
-
-        protected virtual IEnumerable<IIndexDocumentBuilder> GetDocumentBuilders(string documentType, IIndexDocumentChangesProvider provider)
-        {
-            return _configurations.GetDocumentBuilders(documentType, provider?.GetType());
-        }
-
-        protected virtual bool GetConfiguration(string documentType, out IndexDocumentConfiguration configuration)
-        {
-            return _configurations.GetConfiguration(documentType, out configuration);
-        }
-
-        protected virtual void ValidateOptions(IndexingOptions options)
-        {
-            if (options == null)
+            foreach (var document in chunkResult)
             {
-                throw new ArgumentNullException(nameof(options));
-            }
-
-            if (string.IsNullOrEmpty(options.DocumentType))
-            {
-                throw new ArgumentException($"{nameof(options.DocumentType)} is empty", nameof(options));
-            }
-
-            options.BatchSize ??= _settingsManager?.GetValue<int>(GeneralSettings.IndexPartitionSize) ?? DefaultBatchSize;
-
-            if (options.BatchSize < 1)
-            {
-                throw new ArgumentException($"{nameof(options.BatchSize)} {options.BatchSize} is less than 1", nameof(options));
+                if (document != null)
+                {
+                    result.Add(document);
+                }
             }
         }
 
-        protected virtual void ReportProgress(Action<IndexingProgress> progressCallback, string documentType, string message)
+        return result;
+    }
+
+    protected virtual IEnumerable<IList<string>> PaginateIds(IList<string> documentIds)
+    {
+        var chunkSize = Math.Max(1, BuilderChunkSize);
+
+        if (documentIds.Count <= chunkSize)
         {
-            ReportProgress(progressCallback, documentType, message, processedCount: 0L, totalCount: null, errors: null);
+            // Defensive copy: builders should not mutate the list, but we don't trust the contract.
+            yield return new List<string>(documentIds);
+            yield break;
         }
 
-        protected virtual void ReportProgress(
-            Action<IndexingProgress> progressCallback,
-            string documentType,
-            string message,
-            long processedCount,
-            long? totalCount,
-            IList<string> errors)
+        for (var i = 0; i < documentIds.Count; i += chunkSize)
         {
-            if (progressCallback == null)
+            var chunk = new List<string>(Math.Min(chunkSize, documentIds.Count - i));
+            for (var j = i; j < documentIds.Count && j < i + chunkSize; j++)
             {
-                return;
+                chunk.Add(documentIds[j]);
             }
+            yield return chunk;
+        }
+    }
 
-            string description;
+    protected virtual void MergeDocuments(IList<IndexDocument> primaryDocuments, IList<IndexDocument> secondaryDocuments)
+    {
+        if (primaryDocuments.IsNullOrEmpty() || secondaryDocuments.IsNullOrEmpty())
+        {
+            return;
+        }
 
-            if (message != null)
+        var secondaryDocumentGroups = secondaryDocuments
+            .GroupBy(d => d.Id)
+            .ToDictionary(g => g.Key, g => g, StringComparer.OrdinalIgnoreCase);
+
+        foreach (var primaryDocument in primaryDocuments)
+        {
+            if (secondaryDocumentGroups.TryGetValue(primaryDocument.Id, out var secondaryDocumentGroup))
             {
-                description = $"{documentType}: {message}";
+                foreach (var secondaryDocument in secondaryDocumentGroup)
+                {
+                    primaryDocument.Merge(secondaryDocument);
+                }
+            }
+        }
+    }
+
+    protected void AggregateDocuments(IList<IndexDocument> documents, IIndexDocumentBuilder primaryDocumentBuilder, IList<IIndexDocumentBuilder> secondaryDocumentBuilders)
+    {
+        var aggregationKeyProvider = GetAggregationKeyProvider(primaryDocumentBuilder, secondaryDocumentBuilders);
+
+        if (aggregationKeyProvider == null)
+        {
+            return;
+        }
+
+        var aggregators = GetDocumentAggregators(primaryDocumentBuilder, secondaryDocumentBuilders);
+
+        if (aggregators.IsNullOrEmpty())
+        {
+            return;
+        }
+
+        var aggregationGroups = aggregationKeyProvider.GetGroups(documents);
+
+        foreach (var aggregator in aggregators)
+        {
+            foreach (var aggregationGroup in aggregationGroups)
+            {
+                aggregator.Aggregate(aggregationGroup);
+            }
+        }
+    }
+
+    protected virtual IIndexDocumentAggregationGroupProvider GetAggregationKeyProvider(IIndexDocumentBuilder primaryDocumentBuilder, IList<IIndexDocumentBuilder> secondaryDocumentBuilders)
+    {
+        if (primaryDocumentBuilder is IIndexDocumentAggregationGroupProvider aggregationKeyProvider)
+        {
+            return aggregationKeyProvider;
+        }
+
+        if (secondaryDocumentBuilders != null)
+        {
+            return secondaryDocumentBuilders.OfType<IIndexDocumentAggregationGroupProvider>().FirstOrDefault();
+        }
+
+        return null;
+    }
+
+    protected virtual IList<IIndexDocumentAggregator> GetDocumentAggregators(IIndexDocumentBuilder primaryDocumentBuilder, IList<IIndexDocumentBuilder> secondaryDocumentBuilders)
+    {
+        var result = new List<IIndexDocumentAggregator>();
+
+        if (primaryDocumentBuilder is IIndexDocumentAggregator primaryDocumentAggregator)
+        {
+            result.Add(primaryDocumentAggregator);
+        }
+
+        if (secondaryDocumentBuilders != null)
+        {
+            result.AddRange(secondaryDocumentBuilders.OfType<IIndexDocumentAggregator>());
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Swap between active and backup indices, if supported
+    /// </summary>
+    protected virtual async Task SwapIndicesAsync(IndexingOptions options)
+    {
+        var documentType = options.DocumentType;
+
+        if (options.DeleteExistingIndex && _searchProvider.Is<ISupportIndexSwap>(documentType, out var swappingSupportedSearchProvider))
+        {
+            await swappingSupportedSearchProvider.SwapIndexAsync(documentType);
+        }
+    }
+
+    private async Task<IndexState> GetIndexStateAsync(string documentType, bool getBackupIndexState)
+    {
+        var result = new IndexState
+        {
+            DocumentType = documentType,
+            Provider = _searchProvider.GetProviderName(documentType, _searchOptions.Provider),
+            Scope = _searchOptions.GetScope(documentType),
+            IsActive = !getBackupIndexState,
+        };
+
+        var searchRequest = new SearchRequest
+        {
+            UseBackupIndex = getBackupIndexState,
+            Sorting = [new SortingField { FieldName = KnownDocumentFields.IndexationDate, IsDescending = true }],
+            Take = 1,
+        };
+
+        try
+        {
+            var searchResponse = await _searchProvider.SearchAsync(documentType, searchRequest);
+
+            result.IndexedDocumentsCount = searchResponse.TotalCount;
+            if (searchResponse.Documents?.Any() == true)
+            {
+                var indexationDate = searchResponse.Documents[0].FirstOrDefault(kvp => kvp.Key.EqualsIgnoreCase(KnownDocumentFields.IndexationDate));
+                if (DateTimeOffset.TryParse(indexationDate.Value.ToString(), out var lastIndexationDateTime))
+                {
+                    result.LastIndexationDate = lastIndexationDateTime.DateTime;
+                }
+            }
+        }
+        catch
+        {
+            // ignored
+        }
+
+        return result;
+    }
+
+    protected virtual async Task PrepareIndexAsync(IndexingOptions options, Action<IndexingProgress> progressCallback, CancellationToken cancellationToken)
+    {
+        if (options.DeleteExistingIndex)
+        {
+            await DeleteIndexAsync(options, progressCallback, cancellationToken);
+            await CreateIndexAsync(options, progressCallback, cancellationToken);
+        }
+    }
+
+    protected virtual async Task DeleteIndexAsync(IndexingOptions options, Action<IndexingProgress> progressCallback, CancellationToken cancellationToken)
+    {
+        var documentType = options.DocumentType;
+        ReportProgress(progressCallback, documentType, "deleting index");
+
+        await _searchProvider.DeleteIndexAsync(documentType);
+        // TODO: Wait until index is deleted
+    }
+
+    protected virtual async Task CreateIndexAsync(IndexingOptions options, Action<IndexingProgress> progressCallback, CancellationToken cancellationToken)
+    {
+        var documentType = options.DocumentType;
+        ReportProgress(progressCallback, documentType, "creating index");
+
+        var schema = await BuildSchemaAsync(documentType);
+
+        if (_searchProvider.Is<ISupportIndexCreate>(documentType, out var supportIndexCreate))
+        {
+            await supportIndexCreate.CreateIndexAsync(documentType, schema);
+        }
+        else
+        {
+            var documents = new[] { schema };
+
+            if (_searchProvider.Is<ISupportIndexSwap>(documentType, out var supportIndexSwapProvider))
+            {
+                await supportIndexSwapProvider.IndexWithBackupAsync(documentType, documents);
             }
             else
             {
-                description = totalCount != null
-                    ? $"{documentType}: {processedCount} of {totalCount} have been indexed"
-                    : $"{documentType}: {processedCount} have been indexed";
+                await _searchProvider.IndexAsync(documentType, documents);
             }
 
-            progressCallback.Invoke(new IndexingProgress(description, documentType, totalCount, processedCount, errors));
+            await _searchProvider.RemoveAsync(documentType, documents);
         }
+    }
+
+    protected virtual async Task<IndexDocument> BuildSchemaAsync(string documentType)
+    {
+        var temporaryDocumentId = Guid.NewGuid().ToString("N");
+        var schema = new IndexDocument(temporaryDocumentId);
+
+        AddSystemFields(schema);
+
+        foreach (var schemaBuilder in GetSchemaBuilders(documentType))
+        {
+            await schemaBuilder.BuildSchemaAsync(schema);
+        }
+
+        return schema;
+    }
+
+    protected virtual void AddSystemFields(IndexDocument document)
+    {
+        document.AddFilterableDateTime(KnownDocumentFields.IndexationDate, DateTime.UtcNow);
+    }
+
+    protected virtual IEnumerable<IIndexSchemaBuilder> GetSchemaBuilders(string documentType)
+    {
+        return _configurations.GetDocumentSources(documentType)
+            .Select(x => x.DocumentBuilder)
+            .OfType<IIndexSchemaBuilder>();
+    }
+
+    protected virtual IEnumerable<IIndexDocumentBuilder> GetDocumentBuilders(string documentType, IIndexDocumentChangesProvider provider)
+    {
+        return _configurations.GetDocumentBuilders(documentType, provider?.GetType());
+    }
+
+    protected virtual bool GetConfiguration(string documentType, out IndexDocumentConfiguration configuration)
+    {
+        return _configurations.GetConfiguration(documentType, out configuration);
+    }
+
+    protected virtual void ValidateOptions(IndexingOptions options)
+    {
+        if (options == null)
+        {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        if (string.IsNullOrEmpty(options.DocumentType))
+        {
+            throw new ArgumentException($"{nameof(options.DocumentType)} is empty", nameof(options));
+        }
+
+        options.BatchSize ??= _settingsManager?.GetValue<int>(GeneralSettings.IndexPartitionSize) ?? DefaultBatchSize;
+
+        if (options.BatchSize < 1)
+        {
+            throw new ArgumentException($"{nameof(options.BatchSize)} {options.BatchSize} is less than 1", nameof(options));
+        }
+    }
+
+    protected virtual void ReportProgress(Action<IndexingProgress> progressCallback, string documentType, string message)
+    {
+        ReportProgress(progressCallback, documentType, message, processedCount: 0L, totalCount: null, errors: null);
+    }
+
+    protected virtual void ReportProgress(
+        Action<IndexingProgress> progressCallback,
+        string documentType,
+        string message,
+        long processedCount,
+        long? totalCount,
+        IList<string> errors)
+    {
+        if (progressCallback == null)
+        {
+            return;
+        }
+
+        string description;
+
+        if (message != null)
+        {
+            description = $"{documentType}: {message}";
+        }
+        else
+        {
+            description = totalCount != null
+                ? $"{documentType}: {processedCount} of {totalCount} have been indexed"
+                : $"{documentType}: {processedCount} have been indexed";
+        }
+
+        progressCallback.Invoke(new IndexingProgress(description, documentType, totalCount, processedCount, errors));
     }
 }

--- a/src/VirtoCommerce.SearchModule.Data/Services/IndexingManager.cs
+++ b/src/VirtoCommerce.SearchModule.Data/Services/IndexingManager.cs
@@ -480,10 +480,10 @@ public class IndexingManager : IIndexingManager
         cancellationToken.ThrowIfCancellationRequested();
 
         var result = new List<IndexDocument>();
-        var configuredChunkSize = _settingsManager?.GetValue<int>(GeneralSettings.IndexPartitionSize);
-        var chunkSize = configuredChunkSize.HasValue && configuredChunkSize.Value > 0 ? configuredChunkSize.Value : DefaultBatchSize;
 
-        foreach (var idChunk in PaginateIds(documentIds, chunkSize))
+        var partitionSize = GetPartitionSize();
+
+        foreach (var idChunk in PaginateIds(documentIds, partitionSize))
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -512,11 +512,9 @@ public class IndexingManager : IIndexingManager
     {
         var result = new List<IndexDocument>();
 
-        var configuredChunkSize = _settingsManager?.GetValue<int>(GeneralSettings.IndexPartitionSize) ?? DefaultBatchSize;
-        var chunkSize = configuredChunkSize > 0 ? configuredChunkSize : DefaultBatchSize;
+        var partitionSize = GetPartitionSize();
 
-
-        foreach (var idChunk in PaginateIds(documentIds, chunkSize))
+        foreach (var idChunk in PaginateIds(documentIds, partitionSize))
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -784,7 +782,7 @@ public class IndexingManager : IIndexingManager
             throw new ArgumentException($"{nameof(options.DocumentType)} is empty", nameof(options));
         }
 
-        options.BatchSize ??= _settingsManager?.GetValue<int>(GeneralSettings.IndexPartitionSize) ?? DefaultBatchSize;
+        options.BatchSize ??= GetPartitionSize();
 
         if (options.BatchSize < 1)
         {
@@ -824,5 +822,12 @@ public class IndexingManager : IIndexingManager
         }
 
         progressCallback.Invoke(new IndexingProgress(description, documentType, totalCount, processedCount, errors));
+    }
+
+    private int GetPartitionSize()
+    {
+        var indexPartitionSize = _settingsManager?.GetValue<int>(GeneralSettings.IndexPartitionSize);
+        var partitionSize = indexPartitionSize.HasValue && indexPartitionSize.Value > 0 ? indexPartitionSize.Value : DefaultBatchSize;
+        return partitionSize;
     }
 }

--- a/src/VirtoCommerce.SearchModule.Data/Services/IndexingManager.cs
+++ b/src/VirtoCommerce.SearchModule.Data/Services/IndexingManager.cs
@@ -112,12 +112,6 @@ public class IndexingManager : IIndexingManager
         return result;
     }
 
-    /// <summary>
-    /// Picks the primary/secondary builders and decides whether the search provider should be
-    /// driven via partial-update for the given <paramref name="documentType"/>.
-    /// Extracted from <see cref="IndexDocumentsAsync(string, string[], IEnumerable{string}, CancellationToken)"/>
-    /// to keep its cyclomatic complexity manageable (Sonar S1541).
-    /// </summary>
     protected virtual IndexDocumentsPlan BuildIndexDocumentsPlan(string documentType, IEnumerable<string> builderTypes, IndexDocumentConfiguration configuration)
     {
         var builderTypesList = (builderTypes as IList<string> ?? builderTypes?.ToList()) ?? Array.Empty<string>();
@@ -351,11 +345,6 @@ public class IndexingManager : IIndexingManager
                 }
                 else
                 {
-                    // Re-check after the build: a builder using the legacy default-impl forwarder
-                    // may not observe the token, and even cancellation-aware builders can return
-                    // normally if the cancel signal arrives between completion and this point.
-                    // Without this check we would commit the in-flight batch after the user's
-                    // "Delete" took effect.
                     cancellationToken.ThrowIfCancellationRequested();
 
                     result = batchOptions.Reindex &&
@@ -491,8 +480,8 @@ public class IndexingManager : IIndexingManager
         cancellationToken.ThrowIfCancellationRequested();
 
         var result = new List<IndexDocument>();
-        var configuredChunkSize = _settingsManager?.GetValue<int>(GeneralSettings.IndexPartitionSize) ?? DefaultBatchSize;
-        var chunkSize = configuredChunkSize > 0 ? configuredChunkSize : DefaultBatchSize;
+        var configuredChunkSize = _settingsManager?.GetValue<int>(GeneralSettings.IndexPartitionSize);
+        var chunkSize = configuredChunkSize.HasValue && configuredChunkSize.Value > 0 ? configuredChunkSize.Value : DefaultBatchSize;
 
         foreach (var idChunk in PaginateIds(documentIds, chunkSize))
         {
@@ -543,9 +532,10 @@ public class IndexingManager : IIndexingManager
 
     protected virtual IEnumerable<IList<string>> PaginateIds(IList<string> documentIds, int chunkSize)
     {
-        // Defense-in-depth: a zero/negative chunk size from a mis-configured setting would make the
-        // `i += chunkSize` loop never advance. Floor to 1 so the iterator always makes progress.
-        chunkSize = Math.Max(1, chunkSize);
+        if (chunkSize < 1)
+        {
+            throw new ArgumentException($"{nameof(chunkSize)} should be greater than 0", nameof(chunkSize));
+        }
 
         if (documentIds.Count <= chunkSize)
         {

--- a/src/VirtoCommerce.SearchModule.Data/Services/IndexingManager.cs
+++ b/src/VirtoCommerce.SearchModule.Data/Services/IndexingManager.cs
@@ -497,10 +497,10 @@ public class IndexingManager : IIndexingManager
     }
 
     /// <summary>
-    /// Calls <paramref name="builder"/> in fixed-size sub-chunks (see <see cref="BuilderChunkSize"/>)
-    /// and polls <paramref name="cancellationToken"/> between chunks so the indexing job aborts
-    /// promptly when its Hangfire entry is deleted, even if individual builder calls are heavy
-    /// (e.g. paginated variation fetches).
+    /// Calls <paramref name="builder"/> in fixed-size sub-chunks sized by the
+    /// <c>VirtoCommerce.Search.IndexPartitionSize</c> setting, polling
+    /// <paramref name="cancellationToken"/> between chunks so the indexing job aborts promptly when
+    /// its Hangfire entry is deleted.
     /// </summary>
     protected virtual async Task<IList<IndexDocument>> BuildDocumentsInChunksAsync(
         IIndexDocumentBuilder builder,

--- a/src/VirtoCommerce.SearchModule.Data/Services/IndexingManager.cs
+++ b/src/VirtoCommerce.SearchModule.Data/Services/IndexingManager.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Settings;
-using VirtoCommerce.SearchModule.Core;
 using VirtoCommerce.SearchModule.Core.Extensions;
 using VirtoCommerce.SearchModule.Core.Model;
 using VirtoCommerce.SearchModule.Core.Services;
@@ -20,34 +19,6 @@ namespace VirtoCommerce.SearchModule.Data.Services;
 public class IndexingManager : IIndexingManager
 {
     public const int DefaultBatchSize = 50;
-
-    /// <summary>
-    /// Number of sub-chunks each change-feed batch is split into before being passed to a document builder.
-    /// A value of N means the cancellation token is polled at least N times per batch, capping the worst-case
-    /// wait between pressing "Delete" in the Hangfire UI and the indexing job aborting at roughly 1/N of a batch.
-    /// </summary>
-    protected const int BuilderChunksPerBatch = 5;
-
-    /// <summary>
-    /// Sub-chunk size used inside <see cref="GetDocumentsAsync"/> when calling individual document builders.
-    /// Derived from the <c>VirtoCommerce.Search.IndexPartitionSize</c> setting so the operator has a single
-    /// knob: lowering the partition size shrinks both change-feed batches AND per-builder calls, improving
-    /// cancellation responsiveness at the cost of more round-trips. Computed as
-    /// <c>max(1, IndexPartitionSize / <see cref="BuilderChunksPerBatch"/>)</c>.
-    /// </summary>
-    protected virtual int BuilderChunkSize
-    {
-        get
-        {
-            var partitionSize = _settingsManager?.GetValue<int>(GeneralSettings.IndexPartitionSize)
-                                ?? ModuleConstants.Settings.DefaultIndexPartitionSize;
-            if (partitionSize <= 0)
-            {
-                partitionSize = ModuleConstants.Settings.DefaultIndexPartitionSize;
-            }
-            return Math.Max(1, partitionSize / BuilderChunksPerBatch);
-        }
-    }
 
     private readonly ISearchProvider _searchProvider;
     private readonly IEnumerable<IndexDocumentConfiguration> _configurations;
@@ -506,8 +477,10 @@ public class IndexingManager : IIndexingManager
         cancellationToken.ThrowIfCancellationRequested();
 
         var result = new List<IndexDocument>();
+        var chunkSize = _settingsManager?.GetValue<int>(GeneralSettings.IndexPartitionSize) ?? DefaultBatchSize;
 
-        foreach (var idChunk in PaginateIds(documentIds))
+
+        foreach (var idChunk in PaginateIds(documentIds, chunkSize))
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -535,8 +508,10 @@ public class IndexingManager : IIndexingManager
         CancellationToken cancellationToken)
     {
         var result = new List<IndexDocument>();
+        var chunkSize = _settingsManager?.GetValue<int>(GeneralSettings.IndexPartitionSize) ?? DefaultBatchSize;
 
-        foreach (var idChunk in PaginateIds(documentIds))
+
+        foreach (var idChunk in PaginateIds(documentIds, chunkSize))
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -550,10 +525,8 @@ public class IndexingManager : IIndexingManager
         return result;
     }
 
-    protected virtual IEnumerable<IList<string>> PaginateIds(IList<string> documentIds)
+    protected virtual IEnumerable<IList<string>> PaginateIds(IList<string> documentIds, int chunkSize)
     {
-        var chunkSize = Math.Max(1, BuilderChunkSize);
-
         if (documentIds.Count <= chunkSize)
         {
             // Defensive copy: builders should not mutate the list, but we don't trust the contract.

--- a/src/VirtoCommerce.SearchModule.Data/Services/IndexingManager.cs
+++ b/src/VirtoCommerce.SearchModule.Data/Services/IndexingManager.cs
@@ -477,7 +477,8 @@ public class IndexingManager : IIndexingManager
         cancellationToken.ThrowIfCancellationRequested();
 
         var result = new List<IndexDocument>();
-        var chunkSize = _settingsManager?.GetValue<int>(GeneralSettings.IndexPartitionSize) ?? DefaultBatchSize;
+        var configuredChunkSize = _settingsManager?.GetValue<int>(GeneralSettings.IndexPartitionSize) ?? DefaultBatchSize;
+        var chunkSize = configuredChunkSize > 0 ? configuredChunkSize : DefaultBatchSize;
 
         foreach (var idChunk in PaginateIds(documentIds, chunkSize))
         {
@@ -507,7 +508,9 @@ public class IndexingManager : IIndexingManager
         CancellationToken cancellationToken)
     {
         var result = new List<IndexDocument>();
-        var chunkSize = _settingsManager?.GetValue<int>(GeneralSettings.IndexPartitionSize) ?? DefaultBatchSize;
+
+        var configuredChunkSize = _settingsManager?.GetValue<int>(GeneralSettings.IndexPartitionSize) ?? DefaultBatchSize;
+        var chunkSize = configuredChunkSize > 0 ? configuredChunkSize : DefaultBatchSize;
 
 
         foreach (var idChunk in PaginateIds(documentIds, chunkSize))
@@ -526,6 +529,10 @@ public class IndexingManager : IIndexingManager
 
     protected virtual IEnumerable<IList<string>> PaginateIds(IList<string> documentIds, int chunkSize)
     {
+        // Defense-in-depth: a zero/negative chunk size from a mis-configured setting would make the
+        // `i += chunkSize` loop never advance. Floor to 1 so the iterator always makes progress.
+        chunkSize = Math.Max(1, chunkSize);
+
         if (documentIds.Count <= chunkSize)
         {
             // Defensive copy: builders should not mutate the list, but we don't trust the contract.

--- a/src/VirtoCommerce.SearchModule.Web/package-lock.json
+++ b/src/VirtoCommerce.SearchModule.Web/package-lock.json
@@ -855,9 +855,9 @@
       "dev": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {

--- a/tests/VirtoCommerce.SearchModule.Tests/DocumentSource.cs
+++ b/tests/VirtoCommerce.SearchModule.Tests/DocumentSource.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using VirtoCommerce.SearchModule.Core.Model;
 using VirtoCommerce.SearchModule.Core.Services;
@@ -58,7 +59,7 @@ namespace VirtoCommerce.SearchModule.Tests
             return Task.FromResult(result);
         }
 
-        public virtual Task<IList<IndexDocument>> GetDocumentsAsync(IList<string> documentIds)
+        public virtual Task<IList<IndexDocument>> GetDocumentsAsync(IList<string> documentIds, CancellationToken cancellationToken)
         {
             var validDocumentIds = DocumentIds?.Intersect(documentIds) ?? documentIds;
             IList<IndexDocument> result = validDocumentIds.Select(id => CreateDocument(id, Name)).ToArray();

--- a/tests/VirtoCommerce.SearchModule.Tests/DocumentSource.cs
+++ b/tests/VirtoCommerce.SearchModule.Tests/DocumentSource.cs
@@ -66,6 +66,11 @@ namespace VirtoCommerce.SearchModule.Tests
             return Task.FromResult(result);
         }
 
+        public Task<IList<IndexDocument>> GetDocumentsAsync(IList<string> documentIds)
+        {
+            return GetDocumentsAsync(documentIds, CancellationToken.None);
+        }
+
 
         protected static IndexDocument CreateDocument(string id, string fieldName)
         {
@@ -90,5 +95,6 @@ namespace VirtoCommerce.SearchModule.Tests
 
             return result;
         }
+
     }
 }

--- a/tests/VirtoCommerce.SearchModule.Tests/IndexingManagerTests.cs
+++ b/tests/VirtoCommerce.SearchModule.Tests/IndexingManagerTests.cs
@@ -52,7 +52,7 @@ namespace VirtoCommerce.SearchModule.Tests
                 BatchSize = batchSize,
             };
 
-            await manager.IndexAsync(options, p => progress.Add(p), new CancellationTokenWrapper(cancellationTokenSource.Token));
+            await manager.IndexAsync(options, p => progress.Add(p), cancellationTokenSource.Token);
 
             var expectedBatchesCount = GetExpectedBatchesCount(rebuild, documentSources, batchSize);
             var expectedProgressItemsCount = (rebuild ? 2 : 0) + 1 + expectedBatchesCount + 1;
@@ -103,7 +103,7 @@ namespace VirtoCommerce.SearchModule.Tests
                 BatchSize = batchSize,
             };
 
-            await manager.IndexAsync(options, p => progress.Add(p), new CancellationTokenWrapper(cancellationTokenSource.Token));
+            await manager.IndexAsync(options, p => progress.Add(p), cancellationTokenSource.Token);
 
             var expectedBatchesCount = GetBatchesCount(options.DocumentIds.Count, batchSize);
             var expectedProgressItemsCount = 1 + expectedBatchesCount + 1;
@@ -269,6 +269,116 @@ namespace VirtoCommerce.SearchModule.Tests
                 ChangesProvider = documentSource,
                 DocumentBuilder = documentSource,
             };
+        }
+
+
+        // ----------------------------------------------------------------------
+        // Cancellation behavior tests for the Hangfire-deletion fix.
+        // These guard:
+        //  - that cancellation is honored before any builder is called,
+        //  - that sub-chunk pagination inside GetDocumentsAsync polls the token between chunks
+        //    so a single large batch does not run to completion after a token is cancelled,
+        //  - that the cancellation-aware IndexDocumentsAsync overload throws when given a
+        //    pre-cancelled token.
+        // ----------------------------------------------------------------------
+
+        [Fact]
+        public async Task IndexAsync_WhenTokenAlreadyCancelled_ThrowsImmediately()
+        {
+            var documentSources = GetDocumentSources([Primary]);
+            var manager = GetIndexingManager(new SearchProvider(), documentSources);
+
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            var options = new IndexingOptions
+            {
+                DocumentType = DocumentType,
+                BatchSize = 50,
+            };
+
+            await Assert.ThrowsAsync<OperationCanceledException>(() =>
+                manager.IndexAsync(options, _ => { }, cts.Token));
+        }
+
+        /// <summary>
+        /// Production parity: with the default <c>IndexPartitionSize = 50</c> and the
+        /// <c>BuilderChunkSize = max(1, IndexPartitionSize / BuilderChunksPerBatch)</c> derivation,
+        /// a 50-document batch is split into 5 sub-chunks of 10 — exactly the configuration this
+        /// test asserts against. The test is a regression guard for the sub-chunking loop in
+        /// <c>IndexingManager.BuildDocumentsInChunksAsync</c>: the cancellation token must be
+        /// polled between chunks so a token cancelled mid-batch aborts before the remaining work.
+        /// </summary>
+        [Fact]
+        public async Task IndexAsync_TokenCancelledDuringFirstChunk_StopsBeforeRemainingChunks()
+        {
+            const int totalDocuments = 50;
+            const int expectedTotalChunks = 5; // totalDocuments / BuilderChunkSize at default settings
+
+            var primary = new CountingDocumentSource(Primary)
+            {
+                DocumentIds = Enumerable.Range(0, totalDocuments).Select(i => "id" + i).ToArray(),
+            };
+
+            using var cts = new CancellationTokenSource();
+            primary.OnGetDocuments = callNumber =>
+            {
+                if (callNumber == 1)
+                {
+                    cts.Cancel();
+                }
+            };
+
+            var manager = GetIndexingManager(new SearchProvider(), [primary]);
+
+            var options = new IndexingOptions
+            {
+                DocumentType = DocumentType,
+                DeleteExistingIndex = true,
+                BatchSize = totalDocuments,
+            };
+
+            await Assert.ThrowsAsync<OperationCanceledException>(() =>
+                manager.IndexAsync(options, _ => { }, cts.Token));
+
+            // The token is cancelled inside the first builder call. The next iteration of
+            // BuildDocumentsInChunksAsync polls the token before invoking the builder, so
+            // the abort happens after exactly 1 chunk and well before the full 5.
+            Assert.True(primary.GetDocumentsCallCount < expectedTotalChunks,
+                $"Expected sub-chunking to abort early, but builder ran {primary.GetDocumentsCallCount}/{expectedTotalChunks} chunks.");
+            Assert.Equal(1, primary.GetDocumentsCallCount);
+        }
+
+        [Fact]
+        public async Task IndexDocumentsAsync_TokenAware_PreCancelledTokenThrows()
+        {
+            var documentSources = GetDocumentSources([Primary]);
+            var manager = GetIndexingManager(new SearchProvider(), documentSources);
+
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            await Assert.ThrowsAsync<OperationCanceledException>(() =>
+                manager.IndexDocumentsAsync(DocumentType, ["good2", "good3"], builderTypes: null,
+                    cts.Token));
+        }
+
+
+        private sealed class CountingDocumentSource : DocumentSource
+        {
+            private int _getDocumentsCallCount;
+
+            public CountingDocumentSource(string name) : base(name) { }
+
+            public int GetDocumentsCallCount => _getDocumentsCallCount;
+            public Action<int> OnGetDocuments { get; set; }
+
+            public override Task<IList<IndexDocument>> GetDocumentsAsync(IList<string> documentIds, CancellationToken cancellationToken)
+            {
+                var n = Interlocked.Increment(ref _getDocumentsCallCount);
+                OnGetDocuments?.Invoke(n);
+                return base.GetDocumentsAsync(documentIds, cancellationToken);
+            }
         }
     }
 }

--- a/tests/VirtoCommerce.SearchModule.Tests/IndexingManagerTests.cs
+++ b/tests/VirtoCommerce.SearchModule.Tests/IndexingManagerTests.cs
@@ -240,7 +240,10 @@ namespace VirtoCommerce.SearchModule.Tests
         }
 
 
-        private static IIndexingManager GetIndexingManager(ISearchProvider searchProvider, IList<DocumentSource> documentSources)
+        private static IIndexingManager GetIndexingManager(
+            ISearchProvider searchProvider,
+            IList<DocumentSource> documentSources,
+            int? indexPartitionSize = null)
         {
             var primaryDocumentSource = documentSources?.FirstOrDefault();
 
@@ -258,6 +261,19 @@ namespace VirtoCommerce.SearchModule.Tests
                 {
                     Value = true
                 });
+
+            if (indexPartitionSize.HasValue)
+            {
+                // Pin VirtoCommerce.Search.IndexPartitionSize so tests that need a specific
+                // sub-chunk size in BuildDocumentsInChunksAsync can override it without depending
+                // on the production default.
+                settingsManager
+                    .Setup(x => x.GetObjectSettingAsync(ModuleConstants.Settings.General.IndexPartitionSize.Name, null, null))
+                    .ReturnsAsync(new ObjectSettingEntry
+                    {
+                        Value = indexPartitionSize.Value
+                    });
+            }
 
             return new IndexingManager(searchProvider, [configuration], new Mock<IOptions<SearchOptions>>().Object, settingsManager.Object, Array.Empty<IIndexDocumentConverter>());
         }
@@ -302,18 +318,25 @@ namespace VirtoCommerce.SearchModule.Tests
         }
 
         /// <summary>
-        /// Production parity: with the default <c>IndexPartitionSize = 50</c> and the
-        /// <c>BuilderChunkSize = max(1, IndexPartitionSize / BuilderChunksPerBatch)</c> derivation,
-        /// a 50-document batch is split into 5 sub-chunks of 10 — exactly the configuration this
-        /// test asserts against. The test is a regression guard for the sub-chunking loop in
-        /// <c>IndexingManager.BuildDocumentsInChunksAsync</c>: the cancellation token must be
-        /// polled between chunks so a token cancelled mid-batch aborts before the remaining work.
+        /// Regression guard for the sub-chunking loop in <c>IndexingManager.BuildDocumentsInChunksAsync</c>:
+        /// the cancellation token must be polled between sub-chunks so a token cancelled mid-batch
+        /// aborts before the remaining sub-chunks run.
         /// </summary>
+        /// <remarks>
+        /// In production, <c>BuildDocumentsInChunksAsync</c> reads its chunk size from the
+        /// <c>VirtoCommerce.Search.IndexPartitionSize</c> setting — the same setting that drives
+        /// the change-feed batch size. With both equal under default settings, a batch produces
+        /// exactly one sub-chunk and the inter-chunk cancellation path never executes. To make the
+        /// test exercise that path, this fixture pins <c>IndexPartitionSize</c> to <c>10</c> via
+        /// the mock <c>ISettingsManager</c> while keeping <c>IndexingOptions.BatchSize = 50</c> —
+        /// forcing a 50-document batch to be split into five 10-document sub-chunks.
+        /// </remarks>
         [Fact]
         public async Task IndexAsync_TokenCancelledDuringFirstChunk_StopsBeforeRemainingChunks()
         {
             const int totalDocuments = 50;
-            const int expectedTotalChunks = 5; // totalDocuments / BuilderChunkSize at default settings
+            const int subChunkSize = 10;
+            const int expectedTotalChunks = totalDocuments / subChunkSize; // 5
 
             var primary = new CountingDocumentSource(Primary)
             {
@@ -329,7 +352,7 @@ namespace VirtoCommerce.SearchModule.Tests
                 }
             };
 
-            var manager = GetIndexingManager(new SearchProvider(), [primary]);
+            var manager = GetIndexingManager(new SearchProvider(), [primary], indexPartitionSize: subChunkSize);
 
             var options = new IndexingOptions
             {
@@ -343,9 +366,9 @@ namespace VirtoCommerce.SearchModule.Tests
 
             // The token is cancelled inside the first builder call. The next iteration of
             // BuildDocumentsInChunksAsync polls the token before invoking the builder, so
-            // the abort happens after exactly 1 chunk and well before the full 5.
+            // the abort happens after exactly 1 sub-chunk and well before the full 5.
             Assert.True(primary.GetDocumentsCallCount < expectedTotalChunks,
-                $"Expected sub-chunking to abort early, but builder ran {primary.GetDocumentsCallCount}/{expectedTotalChunks} chunks.");
+                $"Expected sub-chunking to abort early, but builder ran {primary.GetDocumentsCallCount}/{expectedTotalChunks} sub-chunks.");
             Assert.Equal(1, primary.GetDocumentsCallCount);
         }
 


### PR DESCRIPTION
## Description
feat: Adds support for cancellation tokens for hangfire background jobs

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5000
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Search_3.1001.0-pr-135-415b.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core indexing interfaces and Hangfire job signatures to propagate `CancellationToken`, which can affect third-party implementations and job execution/cancellation behavior; changes are largely backwards-compatible via `[Obsolete]` shims but still impact critical indexing flows.
> 
> **Overview**
> Adds cancellation-aware overloads (with `[Obsolete]` legacy shims) across indexing contracts: `IIndexDocumentBuilder`, `IIndexDocumentChangesProvider`, `IIndexDocumentChangeFeed`/`Factory`, and `IIndexingManager`.
> 
> Updates Hangfire `IndexingJobs` to use `CancellationToken` end-to-end (including per-queue bulk index/delete methods), adds compatibility overloads for already-enqueued `IJobCancellationToken` jobs, improves `CancelJob` matching across overloads, and logs cancellations via `ILogger`.
> 
> Refactors `IndexingManager` to pass tokens through change-feed iteration and document building, and introduces sub-chunked document fetching (`BuildDocumentsInChunksAsync`) that polls cancellation between chunks for faster aborts. Tests are updated/added to assert immediate and mid-batch cancellation behavior; `package-lock.json` bumps `fast-uri` dev dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 415bc4629bc094d3fca894d87c9f7a730a09bf82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->