### PR TITLE
fix(indexing): always seal the run's own notification on finish (VCST-5091)

### DIFF
--- a/src/VirtoCommerce.SearchModule.Data/BackgroundJobs/IndexProgressHandler.cs
+++ b/src/VirtoCommerce.SearchModule.Data/BackgroundJobs/IndexProgressHandler.cs
@@ -31,7 +31,7 @@ namespace VirtoCommerce.SearchModule.Data.BackgroundJobs
             _pushNotificationManager = pushNotificationManager;
         }
 
-        public void Start(string currentUserName, string notificationId, bool suppressInsignificantNotifications, PerformContext context)
+        public IndexProgressPushNotification Start(string currentUserName, string notificationId, bool suppressInsignificantNotifications, PerformContext context)
         {
             _notification = GetNotification(currentUserName, notificationId);
 
@@ -47,6 +47,10 @@ namespace VirtoCommerce.SearchModule.Data.BackgroundJobs
 
             _context.WriteLine(ConsoleTextColor.White, _notification.Description);
             _progressBar = _context.WriteProgressBar();
+
+            // Return the notification owned by THIS run so the caller can seal exactly this one,
+            // even if a concurrent indexation reassigns the handler's shared _notification field.
+            return _notification;
         }
 
         public void AlreadyInProgress()
@@ -95,44 +99,68 @@ namespace VirtoCommerce.SearchModule.Data.BackgroundJobs
 
         public void Exception(Exception ex)
         {
+            Exception(ex, _notification);
+        }
+
+        // Records the error on a specific notification so it is attributed to the run that failed,
+        // independent of any concurrent run reassigning the handler's shared _notification. See VCST-5091.
+        public void Exception(Exception ex, IndexProgressPushNotification notification)
+        {
             var errorMessage = ex.ToString();
 #pragma warning disable CA2254 // Template should be a static expression
             _log.LogError(errorMessage);
 #pragma warning restore CA2254 // Template should be a static expression
             _context.WriteLine(ConsoleTextColor.Red, errorMessage);
-            _notification.Errors.Add(errorMessage);
-            _notification.ErrorCount++;
+
+            notification ??= _notification;
+            notification.Errors.Add(errorMessage);
+            notification.ErrorCount++;
         }
 
         public void Finish()
         {
+            Finish(_notification);
+        }
+
+        // Seals a specific notification (sets Finished + terminal Description) and pushes it to the client.
+        // Taking the notification explicitly lets each indexation run finish the notification it started,
+        // so a concurrent run that reassigns the handler's shared _notification cannot leave an
+        // earlier run's notification stuck without a Finished timestamp (the Admin "Indexation" blade
+        // spins "In progress" until Finished is set). See VCST-5091.
+        public void Finish(IndexProgressPushNotification notification)
+        {
+            if (notification == null)
+            {
+                return;
+            }
+
             var totalCount = _totalCountMap.Values.Sum();
             var processedCount = _processedCountMap.Values.Sum();
 
-            _notification.Finished = DateTime.UtcNow;
-            _notification.TotalCount = totalCount;
-            _notification.ProcessedCount = processedCount;
+            notification.Finished = DateTime.UtcNow;
+            notification.TotalCount = totalCount;
+            notification.ProcessedCount = processedCount;
 
             if (_isCanceled)
             {
-                _notification.Description = "Indexation has been canceled";
+                notification.Description = "Indexation has been canceled";
             }
             else
             {
-                _notification.Description = !_suppressInsignificantNotifications
-                    ? "Indexation completed" + (_notification.ErrorCount > 0 ? " with errors" : " successfully")
-                    : $"{_notification.DocumentType}: Indexation completed. Total: {totalCount}, Processed: {processedCount}, Errors: {_notification.ErrorCount}.";
+                notification.Description = !_suppressInsignificantNotifications
+                    ? "Indexation completed" + (notification.ErrorCount > 0 ? " with errors" : " successfully")
+                    : $"{notification.DocumentType}: Indexation completed. Total: {totalCount}, Processed: {processedCount}, Errors: {notification.ErrorCount}.";
             }
 
-            _log.LogTrace(_notification.Description);
+            _log.LogTrace(notification.Description);
 
             if (!_suppressInsignificantNotifications || _isCanceled || totalCount > 0 || processedCount > 0)
             {
-                _pushNotificationManager.Send(_notification);
+                _pushNotificationManager.Send(notification);
             }
 
-            UpdateHangfireProgressBar(processedCount, totalCount, _notification.DocumentType);
-            _context.WriteLine(ConsoleTextColor.White, _notification.Description);
+            UpdateHangfireProgressBar(processedCount, totalCount, notification.DocumentType);
+            _context.WriteLine(ConsoleTextColor.White, notification.Description);
         }
 
         public static IndexProgressPushNotification CreateNotification(string currentUserName, string notificationId)

--- a/src/VirtoCommerce.SearchModule.Data/BackgroundJobs/IndexProgressHandler.cs
+++ b/src/VirtoCommerce.SearchModule.Data/BackgroundJobs/IndexProgressHandler.cs
@@ -147,8 +147,9 @@ namespace VirtoCommerce.SearchModule.Data.BackgroundJobs
             }
             else
             {
+                var resultSuffix = notification.ErrorCount > 0 ? " with errors" : " successfully";
                 notification.Description = !_suppressInsignificantNotifications
-                    ? "Indexation completed" + (notification.ErrorCount > 0 ? " with errors" : " successfully")
+                    ? "Indexation completed" + resultSuffix
                     : $"{notification.DocumentType}: Indexation completed. Total: {totalCount}, Processed: {processedCount}, Errors: {notification.ErrorCount}.";
             }
 

--- a/src/VirtoCommerce.SearchModule.Data/BackgroundJobs/IndexingJobs.cs
+++ b/src/VirtoCommerce.SearchModule.Data/BackgroundJobs/IndexingJobs.cs
@@ -121,17 +121,11 @@ public sealed class IndexingJobs : IIndexingJobService
     // ShutdownToken only fires on server shutdown (NOT Hangfire-side deletion), so jobs that
     // flow through the shim are less responsive to "Delete" until the queue has fully drained.
     [Queue(JobPriority.Normal)]
-    public async Task IndexAllDocumentsJob(string userName, string notificationId, IndexingOptions[] options, PerformContext context, CancellationToken cancellationToken)
+    public Task IndexAllDocumentsJob(string userName, string notificationId, IndexingOptions[] options, PerformContext context, CancellationToken cancellationToken)
     {
-        try
-        {
-            await RunIndexJobAsync(userName, notificationId, false, options, IndexAllDocumentsAsync, context, cancellationToken);
-        }
-        finally
-        {
-            // Report indexation summary
-            _progressHandler.Finish();
-        }
+        // The notification is sealed inside RunIndexJobAsync's finally (for both manual and recurring
+        // jobs), so each run finishes the notification it actually started. See VCST-5091.
+        return RunIndexJobAsync(userName, notificationId, false, options, IndexAllDocumentsAsync, context, cancellationToken);
     }
 
     [Queue(JobPriority.Normal)]
@@ -388,8 +382,11 @@ public sealed class IndexingJobs : IIndexingJobService
 
         var success = false;
 
-        // Reset progress handler to initial state
-        _progressHandler.Start(currentUserName, notificationId, suppressInsignificantNotifications, context);
+        // Reset progress handler to initial state.
+        // Capture the notification owned by THIS run so it is always sealed (Finished set) below,
+        // even if a concurrent indexation reassigns the shared handler state. Otherwise the
+        // Admin "Indexation" blade keeps spinning "In progress" forever (VCST-5091).
+        var notification = _progressHandler.Start(currentUserName, notificationId, suppressInsignificantNotifications, context);
 
         // Make sure only one indexation job can run in the cluster.
         // CAUTION: locking mechanism assumes single threaded execution.
@@ -416,15 +413,14 @@ public sealed class IndexingJobs : IIndexingJobService
                 }
                 catch (Exception ex)
                 {
-                    _progressHandler.Exception(ex);
+                    _progressHandler.Exception(ex, notification);
                 }
                 finally
                 {
-                    // Report indexation summary only for "Recurring job for automatic changes indexation."
-                    if (notificationId.IsNullOrEmpty())
-                    {
-                        _progressHandler.Finish();
-                    }
+                    // Always seal this run's notification so it reaches a terminal state.
+                    // (Previously deferred to IndexAllDocumentsJob's outer finally for manual jobs,
+                    // which sealed whatever the shared _notification pointed at by then.)
+                    _progressHandler.Finish(notification);
                 }
             }
         }

--- a/tests/VirtoCommerce.SearchModule.Tests/IndexationFinishOnErrorTests.cs
+++ b/tests/VirtoCommerce.SearchModule.Tests/IndexationFinishOnErrorTests.cs
@@ -1,0 +1,185 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Hangfire;
+using Hangfire.MemoryStorage;
+using Hangfire.Server;
+using Hangfire.Storage;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using VirtoCommerce.Platform.Core.PushNotifications;
+using VirtoCommerce.Platform.Core.Settings;
+using VirtoCommerce.SearchModule.Core.Model;
+using VirtoCommerce.SearchModule.Core.Services;
+using VirtoCommerce.SearchModule.Data.BackgroundJobs;
+using Xunit;
+
+namespace VirtoCommerce.SearchModule.Tests;
+
+// Regression coverage for VCST-5091:
+// When a fatal exception is thrown during a MANUALLY-triggered full indexation
+// (non-empty notificationId), the IndexProgressPushNotification.Finished timestamp
+// must still be set so the Admin "Indexation" blade leaves the "In progress" state.
+public class IndexationFinishOnErrorTests
+{
+    public IndexationFinishOnErrorTests()
+    {
+        // A real (in-memory) Hangfire storage so RunIndexJobAsync can acquire the
+        // distributed "IndexationJob" lock and build a PerformContext exactly like production.
+        JobStorage.Current = new MemoryStorage();
+    }
+
+    [Fact]
+    public async Task ManualIndexation_WhenIndexationThrows_SealsNotificationFinished_VCST5091()
+    {
+        // Arrange
+        var pushManager = new FakePushNotificationManager();
+
+        // The notification the Admin blade polls is created at Enqueue time (Finished == null).
+        var notification = IndexProgressHandler.CreateNotification("admin", null);
+        pushManager.Add(notification);
+
+        var handler = new IndexProgressHandler(NullLogger<IndexProgressHandler>.Instance, pushManager);
+
+        // ISearchProvider.CreateIndexAsync / IndexingManager.IndexAllDocumentsAsync rejects the
+        // index definition with a fatal error (mirrors Azure/Elastic/OpenSearch rejection).
+        var indexingManager = new ThrowingIndexingManager();
+
+        var documentConfigs = new[]
+        {
+            new IndexDocumentConfiguration { DocumentType = "Member" },
+        };
+
+        var jobs = new IndexingJobs(documentConfigs, indexingManager, new Mock<ISettingsManager>().Object, handler, NullLogger<IndexingJobs>.Instance);
+
+        var options = new[] { new IndexingOptions { DocumentType = "Member" } };
+        var context = CreatePerformContext();
+
+        // Act: run the manual job (non-empty notificationId) whose indexation throws.
+        await jobs.IndexAllDocumentsJob("admin", notification.Id, options, context, CancellationToken.None);
+
+        // Assert: the blade-polled notification must be sealed (terminal state) with the error recorded.
+        Assert.True(notification.Finished.HasValue,
+            "IndexProgressPushNotification.Finished was never set after a fatal error on a manual indexation job — the Admin blade stays 'In progress' forever (VCST-5091).");
+        Assert.True(notification.ErrorCount > 0, "Expected the fatal error to be recorded on the notification.");
+    }
+
+    // Reproduces the documented trigger: a second manual "Build new index" is enqueued while the
+    // first manual job is still running on the same (reused) IndexProgressHandler DI instance.
+    // The first job's notification must still end sealed.
+    [Fact]
+    public async Task ManualIndexation_WhenSecondJobStartsDuringFirst_FirstNotificationStillSealed_VCST5091()
+    {
+        // Arrange
+        var pushManager = new FakePushNotificationManager();
+
+        var firstNotification = IndexProgressHandler.CreateNotification("admin", null);
+        pushManager.Add(firstNotification);
+
+        var secondNotification = IndexProgressHandler.CreateNotification("admin", null);
+        pushManager.Add(secondNotification);
+
+        var handler = new IndexProgressHandler(NullLogger<IndexProgressHandler>.Instance, pushManager);
+        var documentConfigs = new[] { new IndexDocumentConfiguration { DocumentType = "Member" } };
+        var jobs = new IndexingJobs(documentConfigs, new ReentrantThrowingIndexingManager(), new Mock<ISettingsManager>().Object, handler, NullLogger<IndexingJobs>.Instance);
+
+        IndexingManagerCallback.SecondJob = async () =>
+        {
+            // A second manual indexation is triggered while the first is mid-flight (same handler instance).
+            var secondOptions = new[] { new IndexingOptions { DocumentType = "Member" } };
+            await jobs.IndexAllDocumentsJob("admin", secondNotification.Id, secondOptions, CreatePerformContext(), CancellationToken.None);
+        };
+
+        var options = new[] { new IndexingOptions { DocumentType = "Member" } };
+
+        // Act
+        await jobs.IndexAllDocumentsJob("admin", firstNotification.Id, options, CreatePerformContext(), CancellationToken.None);
+
+        // Assert: BOTH notifications must end sealed.
+        Assert.True(secondNotification.Finished.HasValue, "Second job notification was not sealed.");
+        Assert.True(firstNotification.Finished.HasValue,
+            "First manual job's notification.Finished was lost because a second job reassigned the shared handler state before the first job sealed it (VCST-5091).");
+    }
+
+    private static PerformContext CreatePerformContext()
+    {
+        var storage = JobStorage.Current;
+        var connection = storage.GetConnection();
+        var backgroundJob = new BackgroundJob(Guid.NewGuid().ToString("N"), null, DateTime.UtcNow);
+#pragma warning disable CS0618 // JobCancellationToken is the only public IJobCancellationToken impl available for tests
+        return new PerformContext(storage, connection, backgroundJob, new JobCancellationToken(false));
+#pragma warning restore CS0618
+    }
+
+    private sealed class ThrowingIndexingManager : StubIndexingManager
+    {
+        public override Task IndexAllDocumentsAsync(IndexingOptions options, Action<IndexingProgress> progressCallback, CancellationToken cancellationToken)
+            => throw new InvalidOperationException("Index definition rejected by search provider.");
+    }
+
+    private sealed class ReentrantThrowingIndexingManager : StubIndexingManager
+    {
+        public override async Task IndexAllDocumentsAsync(IndexingOptions options, Action<IndexingProgress> progressCallback, CancellationToken cancellationToken)
+        {
+            var secondJob = IndexingManagerCallback.SecondJob;
+            if (secondJob != null)
+            {
+                IndexingManagerCallback.SecondJob = null;
+                await secondJob();
+            }
+
+            throw new InvalidOperationException("Index definition rejected by search provider.");
+        }
+    }
+
+    private static class IndexingManagerCallback
+    {
+        public static Func<Task> SecondJob;
+    }
+
+    private abstract class StubIndexingManager : IIndexingManager
+    {
+        public Task<IndexState> GetIndexStateAsync(string documentType) => Task.FromResult(new IndexState());
+        public Task<IEnumerable<IndexState>> GetIndicesStateAsync(string documentType) => Task.FromResult(Enumerable.Empty<IndexState>());
+        public abstract Task IndexAllDocumentsAsync(IndexingOptions options, Action<IndexingProgress> progressCallback, CancellationToken cancellationToken);
+        public Task IndexChangesAsync(IndexingOptions options, Action<IndexingProgress> progressCallback, CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task IndexAsync(IndexingOptions options, Action<IndexingProgress> progressCallback, CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+
+    // A stateful test double that mirrors the real PushNotificationManager: notifications are stored
+    // by Id and SearchNotifies returns the same instance, so the handler reuses it across Start() calls.
+    private sealed class FakePushNotificationManager : IPushNotificationManager
+    {
+        private readonly Dictionary<string, PushNotification> _store = new();
+
+        public void Add(PushNotification notification) => _store[notification.Id] = notification;
+
+        public void Send(PushNotification notification) => _store[notification.Id] = notification;
+
+        public Task SendAsync(PushNotification notification)
+        {
+            Send(notification);
+            return Task.CompletedTask;
+        }
+
+        public PushNotificationSearchResult SearchNotifies(string userId, PushNotificationSearchCriteria criteria)
+        {
+            var result = new PushNotificationSearchResult();
+            if (criteria?.Ids != null)
+            {
+                foreach (var id in criteria.Ids)
+                {
+                    if (id != null && _store.TryGetValue(id, out var notification))
+                    {
+                        result.NotifyEvents.Add(notification);
+                    }
+                }
+            }
+
+            result.TotalCount = result.NotifyEvents.Count;
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
> ⚠️ **DO NOT MERGE until human review** — opened by the QA auto-fix pipeline; needs human review + deploy verification.

## Summary
The Admin **Search → Indexation** blade spins **"In progress"** forever after a fatal error during a manually-triggered full indexation.

Root cause is a **shared-state leak**: `IndexingJobs` is registered as a DI **singleton** but reuses a single **transient** `IndexProgressHandler` instance for the whole process lifetime, so the handler's `_notification` field is shared across every indexation run. For manual jobs the notification seal (`IndexProgressHandler.Finish`) was deferred to `IndexAllDocumentsJob`'s outer `finally` (the inner `finally` skipped it via `if (notificationId.IsNullOrEmpty())`). By the time that outer `Finish()` ran, a concurrent/second run could have reassigned the shared `_notification`, so it sealed *whatever the shared field pointed at by then* — leaving the first run's notification with `Finished == null` permanently. The Admin blade renders the spinner while `notification && !notification.finished`, so it never leaves "In progress".

## Fix
- `Start()` now **returns** the `IndexProgressPushNotification` it began for this run.
- `RunIndexJobAsync` captures that notification in a local and **always** seals **that specific** notification in the inner `finally` via `Finish(notification)`, and attributes errors to it via `Exception(ex, notification)`.
- Removed the `if (notificationId.IsNullOrEmpty())` guard around the inner seal and the now-redundant outer `Finish()` in `IndexAllDocumentsJob` (it returns `RunIndexJobAsync(...)` directly).
- Added `Finish(IndexProgressPushNotification)` and `Exception(Exception, IndexProgressPushNotification)` overloads; the original no-arg `Finish()` / `Exception(ex)` are preserved and delegate to the overloads (backward compatible).

## Testing
- 2 new xUnit tests exercise the **real seam** (`IndexAllDocumentsJob` → `RunIndexJobAsync` → `IndexProgressHandler`) using an in-memory Hangfire `MemoryStorage` (real distributed lock + `PerformContext`) and a stateful fake `IPushNotificationManager` that mirrors the production store.
  - Single manual job that throws → notification ends with `Finished != null` and `ErrorCount > 0`.
  - **Second manual job started while the first is mid-flight** on the same handler → **both** notifications end sealed. This test was **RED before / GREEN after** the fix (the lone-job case already passed on old code, confirming the leak — not the lone path — is load-bearing).
- 110 pre-existing tests **unmodified** and green (112 total after the fix).
- `dotnet build -c Debug` clean: **0 warnings, 0 errors** (`TreatWarningsAsErrors=true` honored).

## Risk / scope
- **Single repo** (`vc-module-search`). No public REST/GraphQL/DTO/domain-event/`module.manifest`/DB-schema/migration change.
- Recurring-job path (`notificationId == null`) behavior **unchanged** — it sealed in the inner `finally` before and still does.
- One judgment call: `Start()` widened from `void` → `IndexProgressPushNotification` on a `public` class. Reviewed and ruled non-blocking — `IndexProgressHandler` is an internal transient collaborator (only consumed by `IndexingJobs`), and a `void`→value return-type widening is source-compatible for any existing caller.

Closes nothing automatically — needs deploy verification on QA, then `/qa-verify-fix VCST-5091`.

JIRA: VCST-5091

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5091
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Search_3.1003.0-pr-138-6c22.zip