### PR TITLE
fix(indexing): thread-safe IndexProgressHandler counter maps (VCST-5416)

### DIFF
--- a/src/VirtoCommerce.SearchModule.Data/BackgroundJobs/IndexProgressHandler.cs
+++ b/src/VirtoCommerce.SearchModule.Data/BackgroundJobs/IndexProgressHandler.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using Hangfire.Console;
@@ -42,8 +43,12 @@ namespace VirtoCommerce.SearchModule.Data.BackgroundJobs
             _suppressInsignificantNotifications = suppressInsignificantNotifications;
             _context = context;
             _isCanceled = false;
-            _totalCountMap = new Dictionary<string, long>();
-            _processedCountMap = new Dictionary<string, long>();
+            // Progress() is invoked concurrently across document-type configurations
+            // (IndexingManager.ProcessConfigurationAsync -> ReportProgress), so these counter maps
+            // must be thread-safe. A plain Dictionary corrupts its internal arrays on concurrent
+            // indexer writes -> IndexOutOfRangeException in Dictionary.TryInsert (VCST-5416).
+            _totalCountMap = new ConcurrentDictionary<string, long>();
+            _processedCountMap = new ConcurrentDictionary<string, long>();
 
             _context.WriteLine(ConsoleTextColor.White, _notification.Description);
             _progressBar = _context.WriteProgressBar();

--- a/tests/VirtoCommerce.SearchModule.Tests/IndexProgressConcurrencyTests.cs
+++ b/tests/VirtoCommerce.SearchModule.Tests/IndexProgressConcurrencyTests.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Hangfire;
+using Hangfire.MemoryStorage;
+using Hangfire.Server;
+using Microsoft.Extensions.Logging.Abstractions;
+using VirtoCommerce.Platform.Core.PushNotifications;
+using VirtoCommerce.SearchModule.Core.Model;
+using VirtoCommerce.SearchModule.Data.BackgroundJobs;
+using Xunit;
+
+namespace VirtoCommerce.SearchModule.Tests;
+
+// Regression coverage for VCST-5416:
+// IndexProgressHandler.Progress(...) is invoked concurrently across document-type configurations
+// (IndexingManager.ProcessConfigurationAsync -> ReportProgress). It writes the per-document-type
+// counters via a plain Dictionary<string,long> indexer, which is NOT thread-safe: concurrent
+// Dictionary.TryInsert calls corrupt the internal bucket/entries arrays and throw
+// IndexOutOfRangeException (or InvalidOperationException) under load, crashing indexation and
+// leaving the "Indexation is already in progress" state stuck.
+public class IndexProgressConcurrencyTests
+{
+    public IndexProgressConcurrencyTests()
+    {
+        // Real in-memory Hangfire storage so a production-shaped PerformContext / progress bar can be built.
+        JobStorage.Current = new MemoryStorage();
+    }
+
+    [Fact]
+    public void Progress_CalledConcurrentlyAcrossDocumentTypes_DoesNotCorruptCountersMap_VCST5416()
+    {
+        // Concurrent writes to a plain Dictionary corrupt its internal arrays during a resize (TryInsert),
+        // so the crash is probabilistic. Run several rounds and require EVERY round to survive; on the
+        // unfixed code at least one round throws IndexOutOfRangeException / InvalidOperationException,
+        // making this reliably red. With ConcurrentDictionary all rounds pass.
+        const int rounds = 20;
+        const int threads = 16;
+        const int writesPerThread = 20000;
+
+        var exceptions = new ConcurrentQueue<Exception>();
+
+        for (var round = 0; round < rounds && exceptions.IsEmpty; round++)
+        {
+            var pushManager = new CountingPushNotificationManager();
+            var handler = new IndexProgressHandler(NullLogger<IndexProgressHandler>.Instance, pushManager);
+
+            // Start() initializes the internal counter maps and the Hangfire progress bar.
+            handler.Start("admin", notificationId: null, suppressInsignificantNotifications: true, context: CreatePerformContext());
+
+            var roundIndex = round;
+
+            // Act: fan out Progress(...) across threads, each writing a stream of DISTINCT documentType
+            // keys so the counter dictionaries keep resizing concurrently — exactly the TryInsert window
+            // that corrupts a non-thread-safe Dictionary. Mirrors IndexingManager.ProcessConfigurationAsync
+            // reporting progress from parallel per-configuration streams.
+            Parallel.For(0, threads, new ParallelOptions { MaxDegreeOfParallelism = threads }, threadIndex =>
+            {
+                try
+                {
+                    for (var i = 0; i < writesPerThread; i++)
+                    {
+                        // Distinct key per write keeps the map growing -> continuous resize races.
+                        var documentType = $"DocType-{roundIndex}-{threadIndex}-{i}";
+                        var progress = new IndexingProgress(
+                            description: documentType,
+                            documentType: documentType,
+                            totalCount: writesPerThread,
+                            processedCount: i);
+
+                        handler.Progress(progress);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    // IndexOutOfRangeException / InvalidOperationException from Dictionary corruption lands here.
+                    exceptions.Enqueue(ex);
+                }
+            });
+        }
+
+        // Assert: no concurrency corruption exception was thrown across all rounds.
+        Assert.True(exceptions.IsEmpty,
+            "IndexProgressHandler.Progress threw under concurrent multi-document-type load — the counter maps are not thread-safe (VCST-5416). First error: "
+            + (exceptions.TryPeek(out var first) ? first.ToString() : "<none>"));
+    }
+
+    private static PerformContext CreatePerformContext()
+    {
+        var storage = JobStorage.Current;
+        var connection = storage.GetConnection();
+        var backgroundJob = new BackgroundJob(Guid.NewGuid().ToString("N"), null, DateTime.UtcNow);
+#pragma warning disable CS0618 // JobCancellationToken is the only public IJobCancellationToken impl available for tests
+        return new PerformContext(storage, connection, backgroundJob, new JobCancellationToken(false));
+#pragma warning restore CS0618
+    }
+
+    // Minimal thread-safe push-notification sink: Progress() calls Send() on every iteration,
+    // so the sink itself must not become the source of contention/exceptions.
+    private sealed class CountingPushNotificationManager : IPushNotificationManager
+    {
+        private readonly ConcurrentDictionary<string, PushNotification> _store = new();
+
+        public void Send(PushNotification notification) => _store[notification.Id] = notification;
+
+        public Task SendAsync(PushNotification notification)
+        {
+            Send(notification);
+            return Task.CompletedTask;
+        }
+
+        public PushNotificationSearchResult SearchNotifies(string userId, PushNotificationSearchCriteria criteria)
+            => new() { NotifyEvents = new List<PushNotification>(), TotalCount = 0 };
+    }
+}


### PR DESCRIPTION
## Description
Fixes a thread-safety crash in the search indexer. `IndexProgressHandler._totalCountMap` / `_processedCountMap` were plain `Dictionary<string,long>` written **concurrently** from `Progress()` across document-type configurations (`IndexingManager.ProcessConfigurationAsync` -> `ReportProgress`). Unsynchronized concurrent `Dictionary.TryInsert` corrupts the internal array -> `IndexOutOfRangeException` / `InvalidOperationException` at `IndexProgressHandler.cs:78`, which aborts indexation and leaves the "indexation in progress" state stuck -> Admin **Build index** / REST then return **"Indexation is already in progress"** and the storefront order-history list stays empty for all users.

**Fix (minimal):** both counter maps -> `ConcurrentDictionary<string,long>` (field type stays `IDictionary<string,long>`; per-key indexer writes are atomic; `Finish()`'s `.Values.Sum()` unaffected). New concurrency regression test: RED before (exact corruption signature), GREEN after. `dotnet test` = 114 passed / 0 failed; build clean.

Complements #138 (VCST-5091, notification sealing) — that hardens the finish path; this removes the crash that triggers the stuck "in progress" state.

> [!WARNING]
> **DO NOT MERGE until human review** - opened by the QA auto-fix pipeline; needs human review + deploy verification.

## References
### QA-test:
Post-deploy `/qa-verify-fix VCST-5416`: place an order -> it appears in the storefront order history; Admin **Build index** completes without "Indexation is already in progress".
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5416
### Artifact URL:
[https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Search_3.1006.0-pr-142-28ca.zip](https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Search_3.1006.0-pr-142-28ca.zip)
